### PR TITLE
fix: codebase analysis findings 2026-04-11

### DIFF
--- a/backend/src/mcp/tools/_shared.ts
+++ b/backend/src/mcp/tools/_shared.ts
@@ -50,5 +50,8 @@ export function sanitizeFtsQuery(raw: string): string {
  * literal characters in a LIKE pattern, not wildcards.
  */
 export function escapeLike(value: string): string {
-  return value.replace(/%/g, "\\%").replace(/_/g, "\\_");
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_");
 }

--- a/backend/src/mcp/tools/_shared.ts
+++ b/backend/src/mcp/tools/_shared.ts
@@ -44,3 +44,11 @@ export function periodCutoff(period: Period): string | null {
 export function sanitizeFtsQuery(raw: string): string {
   return raw.replace(/["()*:^]/g, " ").trim();
 }
+
+/**
+ * Escapes SQL LIKE special characters (% and _) so they are treated as
+ * literal characters in a LIKE pattern, not wildcards.
+ */
+export function escapeLike(value: string): string {
+  return value.replace(/%/g, "\\%").replace(/_/g, "\\_");
+}

--- a/backend/src/mcp/tools/dbt.ts
+++ b/backend/src/mcp/tools/dbt.ts
@@ -4,7 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { dbtEntries } from "../../db/index.ts";
 import type { McpToolContext } from "../server.ts";
-import { jsonContent, sanitizeFtsQuery } from "./_shared.ts";
+import { jsonContent, sanitizeFtsQuery, escapeLike } from "./_shared.ts";
 
 export function registerDbtTools(server: McpServer, ctx: McpToolContext): void {
   const { db, rawDb, userId } = ctx;
@@ -34,7 +34,7 @@ export function registerDbtTools(server: McpServer, ctx: McpToolContext): void {
       if (args.from) conditions.push(gte(dbtEntries.entryDate, args.from));
       if (args.to) conditions.push(lte(dbtEntries.entryDate, args.to));
       if (args.emotion_contains) {
-        conditions.push(like(dbtEntries.emotionName, `%${args.emotion_contains}%`));
+        conditions.push(like(dbtEntries.emotionName, `%${escapeLike(args.emotion_contains)}%`));
       }
 
       const rows = db

--- a/backend/src/mcp/tools/dbt.ts
+++ b/backend/src/mcp/tools/dbt.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, gte, lte, like, desc } from "drizzle-orm";
+import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { dbtEntries } from "../../db/index.ts";
@@ -34,7 +34,7 @@ export function registerDbtTools(server: McpServer, ctx: McpToolContext): void {
       if (args.from) conditions.push(gte(dbtEntries.entryDate, args.from));
       if (args.to) conditions.push(lte(dbtEntries.entryDate, args.to));
       if (args.emotion_contains) {
-        conditions.push(like(dbtEntries.emotionName, `%${escapeLike(args.emotion_contains)}%`));
+        conditions.push(sql`${dbtEntries.emotionName} LIKE ${'%' + escapeLike(args.emotion_contains) + '%'} ESCAPE '\\'`);
       }
 
       const rows = db

--- a/backend/src/mcp/tools/pain.ts
+++ b/backend/src/mcp/tools/pain.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, gte, lte, like, desc, sql } from "drizzle-orm";
+import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { painEntries, painOptions } from "../../db/index.ts";
@@ -38,8 +38,8 @@ export function registerPainTools(server: McpServer, ctx: McpToolContext): void 
       if (args.from) conditions.push(gte(painEntries.entryDate, args.from));
       if (args.to) conditions.push(lte(painEntries.entryDate, args.to));
       if (args.level_min !== undefined) conditions.push(gte(painEntries.painLevel, args.level_min));
-      if (args.area) conditions.push(like(painEntries.area, `%${escapeLike(args.area)}%`));
-      if (args.symptoms_contains) conditions.push(like(painEntries.symptoms, `%${escapeLike(args.symptoms_contains)}%`));
+      if (args.area) conditions.push(sql`${painEntries.area} LIKE ${'%' + escapeLike(args.area) + '%'} ESCAPE '\\'`);
+      if (args.symptoms_contains) conditions.push(sql`${painEntries.symptoms} LIKE ${'%' + escapeLike(args.symptoms_contains) + '%'} ESCAPE '\\'`);
 
       const rows = db
         .select({

--- a/backend/src/mcp/tools/pain.ts
+++ b/backend/src/mcp/tools/pain.ts
@@ -4,7 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { painEntries, painOptions } from "../../db/index.ts";
 import type { McpToolContext } from "../server.ts";
-import { jsonContent, periodCutoff, sanitizeFtsQuery } from "./_shared.ts";
+import { jsonContent, periodCutoff, sanitizeFtsQuery, escapeLike } from "./_shared.ts";
 
 export function registerPainTools(server: McpServer, ctx: McpToolContext): void {
   const { db, rawDb, userId } = ctx;
@@ -38,8 +38,8 @@ export function registerPainTools(server: McpServer, ctx: McpToolContext): void 
       if (args.from) conditions.push(gte(painEntries.entryDate, args.from));
       if (args.to) conditions.push(lte(painEntries.entryDate, args.to));
       if (args.level_min !== undefined) conditions.push(gte(painEntries.painLevel, args.level_min));
-      if (args.area) conditions.push(like(painEntries.area, `%${args.area}%`));
-      if (args.symptoms_contains) conditions.push(like(painEntries.symptoms, `%${args.symptoms_contains}%`));
+      if (args.area) conditions.push(like(painEntries.area, `%${escapeLike(args.area)}%`));
+      if (args.symptoms_contains) conditions.push(like(painEntries.symptoms, `%${escapeLike(args.symptoms_contains)}%`));
 
       const rows = db
         .select({

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -27,12 +27,12 @@ export function getSession(db: DrizzleDB, req: Request): SessionData | null {
 
 export function createSession(db: DrizzleDB, userId: number, email: string): string {
   const sid = crypto.randomUUID().replaceAll("-", "");
-  const ttlDays = Math.floor(env.SESSION_TTL_SECONDS / 86400);
+  const ttlSeconds = env.SESSION_TTL_SECONDS;
   db.insert(sessions).values({
     sid,
     userId,
     email,
-    expiresAt: sql`datetime('now', '+' || ${ttlDays} || ' days')`,
+    expiresAt: sql`datetime('now', '+' || ${ttlSeconds} || ' seconds')`,
   }).run();
   return sid;
 }
@@ -60,12 +60,12 @@ export const requireAuth = createMiddleware<{
   }
 
   const me = db
-    .select({ id: users.id, email: users.email, name: users.name })
+    .select({ id: users.id, email: users.email, name: users.name, disabledAt: users.disabledAt })
     .from(users)
     .where(eq(users.id, session.userId))
     .limit(1)
     .get();
-  if (!me) {
+  if (!me || me.disabledAt) {
     return c.json({ error: { code: "UNAUTHORIZED", message: "Authentication required" } }, 401);
   }
 

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -298,6 +298,8 @@ backup.post("/purge", async (c) => {
   const tx = rawDb.transaction(() => {
     rawDb.query(`DELETE FROM pain_entries WHERE user_id = ?`).run(userId);
     rawDb.query(`DELETE FROM diary_entries WHERE user_id = ?`).run(userId);
+    rawDb.query(`DELETE FROM cbt_entries WHERE user_id = ?`).run(userId);
+    rawDb.query(`DELETE FROM dbt_entries WHERE user_id = ?`).run(userId);
     rawDb.query(`DELETE FROM user_preferences WHERE user_id = ?`).run(userId);
   });
   tx();


### PR DESCRIPTION
Closes #60

## Summary

### Security
- **Auth bypass for disabled accounts**: `requireAuth` middleware now checks `users.disabledAt`, blocking sessions for disabled accounts (consistent with MCP auth)
- **LIKE injection in MCP tools**: Added `escapeLike()` helper to escape `%` and `_` wildcards in pain area/symptoms and DBT emotion_contains parameters

### Bugs
- **Purge incomplete**: Added `DELETE FROM cbt_entries` and `DELETE FROM dbt_entries` to purge transaction — CBT/DBT data was previously surviving a full purge
- **Session TTL precision**: Changed from `Math.floor(seconds/86400)` days to exact seconds in `datetime()`, fixing potential TTL mismatch between server-side session expiry and cookie `maxAge`

## Test plan
- [ ] Verify login still works and session is created correctly
- [ ] Verify disabled account cannot access protected routes (via CLI: `user disable <email>`)
- [ ] Verify purge deletes diary, pain, CBT, and DBT entries
- [ ] Verify MCP pain/dbt tools work with normal queries and queries containing % or _ characters
- [ ] Run existing Playwright tests: `bun run test`

---
*Generato automaticamente da Codebase Analyst*