### PR TITLE
ci: add minimal GITHUB_TOKEN permissions block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read` to ci.yml.

Closes 4 code scanning alerts (rule `actions/missing-workflow-permissions`):
- ci.yml:11 (build)
- ci.yml:37 (lint)
- ci.yml:55 (test)
- ci.yml:73 (docker-build)

Workflow-level scope inherits to all jobs. None of them push, comment, or write to the repo, so contents:read is sufficient.

Co-authored-by: Claude <noreply@anthropic.com>