### PR TITLE
fix: codebase analysis findings 2026-05-16

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -168,16 +168,6 @@ export function runMigrations(db: SQLiteDB): void {
   }
 }
 
-export function nowIso(): string {
-  return new Date().toISOString();
-}
-
-export function clampInt(val: unknown, fallback = 0): number {
-  const n = Number(val);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.trunc(n);
-}
-
 export function toNullableInt(val: unknown): number | null {
   if (val === null || val === undefined || val === "") return null;
   const n = Number(val);

--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -4,7 +4,6 @@ import { HTTPException } from "hono/http-exception";
 import cookie from "cookie";
 import { env } from "./env.ts";
 import { TAG_TYPES, type TagType, MOOD_TAG_FIELDS, type MoodTagField } from "./schema.ts";
-import type { SQLiteDB } from "./db.ts";
 
 export const PAIN_MULTI_FIELDS = TAG_TYPES;
 export type PainMultiField = TagType;
@@ -123,8 +122,6 @@ export function rowPainField(row: Record<string, unknown>, field: PainMultiField
   return "";
 }
 
-export const emptyPainOptions = emptyPainTags;
-
 export function mergeOptions(current: string[], incoming: string[]): string[] {
   const out: string[] = [...current];
   const seen = new Set(current.map((value) => value.toLowerCase()));
@@ -135,40 +132,6 @@ export function mergeOptions(current: string[], incoming: string[]): string[] {
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(normalized);
-  }
-  return out;
-}
-
-export function loadPainOptionsForUser(db: SQLiteDB, userId: number): PainTagMap {
-  const rows = db
-    .query<{ field: string; value: string }, [number]>(
-      `SELECT field, value FROM pain_options WHERE user_id = ? ORDER BY id ASC`
-    )
-    .all(userId);
-  const out = emptyPainOptions();
-  for (const row of rows) {
-    if (PAIN_MULTI_FIELDS.includes(row.field as PainMultiField)) {
-      out[row.field as PainMultiField].push(row.value);
-    }
-  }
-  return out;
-}
-
-export function emptyMoodOptions(): MoodTagMap {
-  return { positive_moods: [], negative_moods: [], general_moods: [] };
-}
-
-export function loadMoodOptionsForUser(db: SQLiteDB, userId: number): MoodTagMap {
-  const rows = db
-    .query<{ field: string; value: string }, [number]>(
-      `SELECT field, value FROM mood_options WHERE user_id = ? ORDER BY id ASC`
-    )
-    .all(userId);
-  const out = emptyMoodOptions();
-  for (const row of rows) {
-    if (MOOD_MULTI_FIELDS.includes(row.field as MoodMultiField)) {
-      out[row.field as MoodMultiField].push(row.value);
-    }
   }
   return out;
 }

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 
 import type { DrizzleDB } from "../db/index.ts";
 import type { SQLiteDB } from "../db.ts";
+import { allowedOrigins } from "../env.ts";
 import { requirePat, type McpAuthVars } from "./auth.ts";
 
 import { registerDiaryTools } from "./tools/diary.ts";
@@ -65,12 +66,14 @@ type McpAppEnv = {
 export function createMcpApp(db: DrizzleDB, rawDb: SQLiteDB): Hono<McpAppEnv> {
   const mcp = new Hono<McpAppEnv>();
 
-  // CORS for MCP clients. Permissive because access is gated by PAT and the
-  // server is reachable only over the user's VPN/Tailscale anyway.
   mcp.use(
     "*",
     cors({
-      origin: (origin) => origin ?? "*",
+      origin: (origin) => {
+        if (!origin) return origin;
+        if (allowedOrigins.has(origin)) return origin;
+        return null;
+      },
       allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
       allowHeaders: [
         "Content-Type",

--- a/backend/src/mcp/tools/_shared.ts
+++ b/backend/src/mcp/tools/_shared.ts
@@ -42,7 +42,7 @@ export function periodCutoff(period: Period): string | null {
  * from an LLM-generated query would otherwise cause `fts5: syntax error`.
  */
 export function sanitizeFtsQuery(raw: string): string {
-  return raw.replace(/["()*:^]/g, " ").trim();
+  return raw.replace(/["()*:^[\]]/g, " ").trim();
 }
 
 /**

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { eq, desc } from "drizzle-orm";
 import ExcelJS from "exceljs";
 import type { DrizzleDB } from "../db/index.ts";
-import { diaryEntries, painEntries, userPreferences, painRemovedOptions, memorableDays } from "../db/index.ts";
+import { diaryEntries, painEntries, userPreferences, painRemovedOptions } from "../db/index.ts";
 import type { SQLiteDB } from "../db.ts";
 import { toNullableInt, toNullableNumber } from "../db.ts";
 import {
@@ -267,11 +267,15 @@ backup.post("/xlsx/import", async (c) => {
   const workbook = new ExcelJS.Workbook();
   const contentType = c.req.header("content-type") ?? "";
 
+  const MAX_XLSX_BYTES = 10 * 1024 * 1024; // 10 MB
   if (contentType.includes("multipart/form-data")) {
     const form = await c.req.formData();
     const file = form.get("file");
     if (!(file instanceof File)) {
       return c.json({ error: { code: "MISSING_FILE", message: "Missing uploaded file in 'file' field" } }, 400);
+    }
+    if (file.size > MAX_XLSX_BYTES) {
+      return c.json({ error: { code: "FILE_TOO_LARGE", message: "File exceeds 10 MB limit" } }, 400);
     }
     const arrayBuffer = await file.arrayBuffer();
     await workbook.xlsx.load(arrayBuffer);

--- a/backend/src/routes/cbt.ts
+++ b/backend/src/routes/cbt.ts
@@ -86,6 +86,9 @@ cbt.put("/:id", async (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "CBT entry not found" } }, 404);
+  }
   const body = await parseJson(c, cbtSchema);
   const updated = db
     .update(cbtEntries)
@@ -117,6 +120,9 @@ cbt.delete("/:id", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "CBT entry not found" } }, 404);
+  }
   const deleted = db.delete(cbtEntries).where(and(eq(cbtEntries.id, id), eq(cbtEntries.userId, userId)))
     .returning({ id: cbtEntries.id }).get();
   if (!deleted) {

--- a/backend/src/routes/dbt.ts
+++ b/backend/src/routes/dbt.ts
@@ -80,6 +80,9 @@ dbt.put("/:id", async (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "DBT entry not found" } }, 404);
+  }
   const body = await parseJson(c, dbtSchema);
   const updated = db
     .update(dbtEntries)
@@ -108,6 +111,9 @@ dbt.delete("/:id", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "DBT entry not found" } }, 404);
+  }
   const deleted = db.delete(dbtEntries).where(and(eq(dbtEntries.id, id), eq(dbtEntries.userId, userId)))
     .returning({ id: dbtEntries.id }).get();
   if (!deleted) {

--- a/backend/src/routes/diary.ts
+++ b/backend/src/routes/diary.ts
@@ -2,19 +2,13 @@ import { Hono } from "hono";
 import { eq, and, between, gte, lte, desc, sql } from "drizzle-orm";
 import type { DrizzleDB } from "../db/index.ts";
 import { diaryEntries } from "../db/index.ts";
+import { toNullableNumber } from "../db.ts";
 import type { SQLiteDB } from "../db.ts";
 import { parseJson } from "../helpers.ts";
 import { diarySchema } from "../schemas.ts";
 import { requireAuth } from "../middleware/auth.ts";
 
 type Env = { Variables: { db: DrizzleDB; rawDb: SQLiteDB; userId: number; userEmail: string; sessionSid: string } };
-
-function toNullableNumber(val: unknown): number | null {
-  if (val === null || val === undefined || val === "") return null;
-  const n = Number(val);
-  if (!Number.isFinite(n)) return null;
-  return n;
-}
 
 const diary = new Hono<Env>();
 
@@ -71,9 +65,9 @@ diary.post("/", async (c) => {
       userId,
       entryDate: body.entryDate,
       entryTime: body.entryTime,
-      moodLevel: toNullableNumber(body.moodLevel) as number | null,
-      depressionLevel: toNullableNumber(body.depressionLevel) as number | null,
-      anxietyLevel: toNullableNumber(body.anxietyLevel) as number | null,
+      moodLevel: toNullableNumber(body.moodLevel),
+      depressionLevel: toNullableNumber(body.depressionLevel),
+      anxietyLevel: toNullableNumber(body.anxietyLevel),
       positiveMoods: body.positiveMoods ?? "",
       negativeMoods: body.negativeMoods ?? "",
       generalMoods: body.generalMoods ?? "",
@@ -90,15 +84,18 @@ diary.put("/:id", async (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "Diary entry not found" } }, 404);
+  }
   const body = await parseJson(c, diarySchema);
   const updated = db
     .update(diaryEntries)
     .set({
       entryDate: body.entryDate,
       entryTime: body.entryTime,
-      moodLevel: toNullableNumber(body.moodLevel) as number | null,
-      depressionLevel: toNullableNumber(body.depressionLevel) as number | null,
-      anxietyLevel: toNullableNumber(body.anxietyLevel) as number | null,
+      moodLevel: toNullableNumber(body.moodLevel),
+      depressionLevel: toNullableNumber(body.depressionLevel),
+      anxietyLevel: toNullableNumber(body.anxietyLevel),
       positiveMoods: body.positiveMoods ?? "",
       negativeMoods: body.negativeMoods ?? "",
       generalMoods: body.generalMoods ?? "",
@@ -120,6 +117,9 @@ diary.delete("/:id", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "Diary entry not found" } }, 404);
+  }
   const deleted = db.delete(diaryEntries).where(and(eq(diaryEntries.id, id), eq(diaryEntries.userId, userId)))
     .returning({ id: diaryEntries.id }).get();
   if (!deleted) {

--- a/backend/src/routes/pain.ts
+++ b/backend/src/routes/pain.ts
@@ -3,6 +3,7 @@ import { eq, and, desc, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { DrizzleDB } from "../db/index.ts";
 import { painEntries, painOptions } from "../db/index.ts";
+import { toNullableInt } from "../db.ts";
 import type { SQLiteDB } from "../db.ts";
 import {
   parseJson,
@@ -17,13 +18,6 @@ import { painSchema, optionFieldSchema } from "../schemas.ts";
 import { requireAuth } from "../middleware/auth.ts";
 
 type Env = { Variables: { db: DrizzleDB; rawDb: SQLiteDB; userId: number; userEmail: string; sessionSid: string } };
-
-function toNullableInt(val: unknown): number | null {
-  if (val === null || val === undefined || val === "") return null;
-  const n = Number(val);
-  if (!Number.isFinite(n)) return null;
-  return Math.trunc(n);
-}
 
 function extractPainField(body: z.infer<typeof painSchema>, field: PainMultiField): string {
   const direct = body[field];
@@ -139,6 +133,9 @@ pain.put("/:id", async (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "Pain entry not found" } }, 404);
+  }
   const body = await parseJson(c, painSchema);
   const updated = db
     .update(painEntries)
@@ -170,6 +167,9 @@ pain.delete("/:id", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id) || id <= 0) {
+    return c.json({ error: { code: "NOT_FOUND", message: "Pain entry not found" } }, 404);
+  }
   const deleted = db.delete(painEntries).where(and(eq(painEntries.id, id), eq(painEntries.userId, userId)))
     .returning({ id: painEntries.id }).get();
   if (!deleted) {

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 export const loginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1)
+  email: z.string().email().max(254),
+  password: z.string().min(1).max(72)
 });
 
 export const changePasswordSchema = z.object({
-  currentPassword: z.string().min(1),
-  newPassword: z.string().min(8)
+  currentPassword: z.string().min(1).max(72),
+  newPassword: z.string().min(8).max(72)
 });
 
 export const diarySchema = z.object({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       PORT: 5555
       DB_PATH: /app/data/health.sqlite
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5555,http://127.0.0.1:5555,http://localhost:5173,http://127.0.0.1:5173}
+      COOKIE_SECURE: "true"
     volumes:
       - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- **Security**: cap password/email length in schemas to prevent argon2id DoS; set `COOKIE_SECURE=true` in docker-compose; replace MCP CORS origin-reflection with allowedOrigins allowlist
- **Bugs**: add `Number.isFinite` guard on `:id` params in PUT/DELETE handlers for diary, pain, CBT, DBT (non-numeric id was silently matching zero rows); add `[` and `]` to FTS5 sanitize regex to prevent SQLite syntax errors from unbalanced brackets
- **Quality**: remove duplicate `toNullableNumber`/`toNullableInt` in diary and pain routes (import from `db.ts`); remove unused `memorableDays` import in backup; reject XLSX uploads >10 MB before loading into memory; remove dead exports (`nowIso`, `clampInt` from `db.ts`; three dead helper functions that used the raw SQLiteDB driver instead of Drizzle)

## Findings (deferred — require manual review)

- **Login rate-limiting / account lockout** — no throttle on `POST /api/v1/auth/login`; needs a sliding-window rate limiter middleware
- **`entryDate`/`entryTime` format validation** — date strings accepted as any non-empty string; stored verbatim; corrupt values silently break ordering
- **GitHub Actions SHA pinning** — `ci.yml` uses floating version tags (`@v4`, `@v2`, `@v3`, `@v6`) instead of commit SHAs; security.yml already uses SHAs, ci.yml should match
- **Dependency upgrades with CVEs** — `hono <4.12.18` (auth/session leaks, cookie bypass), `fast-uri <=3.1.1` (path traversal), transitive deps via `@modelcontextprotocol/sdk`; requires `bun update` + regression testing
- **Dockerfile**: floating `oven/bun:1` tag, no `USER` directive in final stage, no `HEALTHCHECK`
- **Emoji catalog eager bundle** — 560 KB parsed at startup; should be a dynamic import inside the Memorable Days component
- **"Show more" buttons** in screens.tsx have no `onClick` handler — UI feature gap, not a bug

## Sub-analyst reports

- **Security**: unbounded password input (argon2id DoS), missing COOKIE_SECURE, MCP CORS reflection, no login rate-limiting, expired session cleanup only at startup, CI actions not SHA-pinned
- **Quality**: duplicate helper functions in 3 files, dead exports in db.ts/helpers.ts, unused import in backup, non-functional "Show more" buttons, hardcoded hex colors in getDeltaStyle, dead props in SettingsSection
- **Bugs**: NaN ids silently 404 in 4 route files, ZodError swallowed in backup JSON import, no format validation on entryDate/entryTime, FTS5 bracket sanitization gap, silent password rehash failure
- **Tests**: auth rejection paths (wrong password, disabled account, unauth requests), CBT/DBT/pain CRUD, MCP PAT lifecycle, backup JSON round-trip, cross-user isolation, FTS sanitization unit tests, memorable-days pure function edge cases
- **Deps**: hono 4.12.12 (10 CVEs, fix: 4.12.18), fast-uri (path traversal via MCP SDK), esbuild via drizzle-kit (dev-only), Dockerfile floating tag, .gitignore missing *.pem/*.key
- **Performance**: unbounded SELECT on diary/pain/cbt/dbt (no LIMIT), emoji catalog eager import (560 KB), in-memory date filtering of full dataset, 2 sequential DB queries per auth check

---
Generated automatically by Codebase Analyst — 2026-05-16