### PR TITLE
ci: auto-sync dependabot lockfile updates

### DIFF
--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -1,0 +1,54 @@
+name: Dependabot lockfile sync
+
+on:
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    name: Sync lockfile
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout PR head branch
+        run: |
+          git fetch origin "$HEAD_REF"
+          git checkout "$HEAD_REF"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.x
+        with:
+          bun-version: 1.3.11
+
+      - name: Regen frontend lockfile
+        working-directory: frontend
+        run: bun install --no-frozen-lockfile
+
+      - name: Regen backend lockfile
+        working-directory: backend
+        run: bun install --no-frozen-lockfile
+
+      - name: Commit + push if lockfiles changed
+        run: |
+          if [[ -z "$(git status --porcelain frontend/bun.lock backend/bun.lock)" ]]; then
+            echo "Lockfiles already in sync; nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/bun.lock backend/bun.lock
+          git commit -m "chore(deps): sync bun.lock after dependabot bump"
+          git push origin "$HEAD_REF"


### PR DESCRIPTION
## Why

Dependabot bumps `package.json` but never `bun.lock`. CI installs with `--frozen-lockfile` and refuses to start when the two disagree. Every dep PR — minor, patch, major — fails the same way. Recent example: PRs #87, #90, #92, #93 all needed a manual lockfile regen before they could merge.

## Fix

New workflow `.github/workflows/dependabot-lockfile-sync.yml`:

- Triggers on `pull_request` only when actor is `dependabot[bot]`
- Checks out the PR head branch
- Runs `bun install --no-frozen-lockfile` in both `frontend/` and `backend/`
- If either `bun.lock` changed, commits + pushes back to the PR branch as `github-actions[bot]`
- Subsequent CI run then sees coherent lockfiles and passes

Permissions narrowed to `contents: write` + `pull-requests: write`. Third-party actions pinned to commit SHAs (matches existing `ci.yml` style, AGENTS.md rule 14). `github.head_ref` passed via `env:` block, not interpolated into `run:` scripts (rule 14 shell-injection guard).

## Test plan

- [ ] Merge this PR.
- [ ] Wait for next dependabot PR.
- [ ] Confirm autosync workflow runs, pushes lockfile commit, and downstream CI passes without manual intervention.

Co-authored-by: Claude <noreply@anthropic.com>