### PR TITLE
perf(dashboard): lazy-load chart.js bundle

### DIFF
--- a/frontend/src/app/WellbeingChart.tsx
+++ b/frontend/src/app/WellbeingChart.tsx
@@ -1,0 +1,23 @@
+import type { ChartData, ChartOptions } from "chart.js";
+import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from "chart.js";
+import "chartjs-adapter-date-fns";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export type WellbeingChartView = {
+  hasAnyData: boolean;
+  hasVisibleData: boolean;
+  data: ChartData<"line", { x: string; y: number }[], string>;
+  options: ChartOptions<"line">;
+};
+
+export default function WellbeingChart({
+  data,
+  options,
+}: {
+  data: WellbeingChartView["data"];
+  options: WellbeingChartView["options"];
+}) {
+  return <Line data={data} options={options} />;
+}

--- a/frontend/src/app/screens.tsx
+++ b/frontend/src/app/screens.tsx
@@ -1,9 +1,6 @@
-import { type CSSProperties, useState } from "react";
-import type { ChartData, ChartOptions } from "chart.js";
+import { type CSSProperties, lazy, Suspense, useState } from "react";
 import { type UseFormReturn } from "react-hook-form";
-import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from "chart.js";
-import "chartjs-adapter-date-fns";
-import { Line } from "react-chartjs-2";
+import type { WellbeingChartView } from "./WellbeingChart";
 import {
   csvToList,
   type CbtEntry,
@@ -38,7 +35,7 @@ import {
   getDeltaStyle,
 } from "./core";
 
-ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+const WellbeingChart = lazy(() => import("./WellbeingChart"));
 
 function formatEntrySummaryDate(entryDate: string, entryTime: string): string {
   const time = entryTime.length >= 5 ? entryTime : `${entryTime}:00`;
@@ -156,13 +153,6 @@ function CoffeeStepper({ value, onChange }: { value: number | null; onChange: (n
     </div>
   );
 }
-
-type WellbeingChartView = {
-  hasAnyData: boolean;
-  hasVisibleData: boolean;
-  data: ChartData<"line", { x: string; y: number }[], string>;
-  options: ChartOptions<"line">;
-};
 
 function EmptyState({
   title,
@@ -336,7 +326,9 @@ export function DashboardSection({
 
             {wellbeingChart.hasVisibleData ? (
               <div className="chart-canvas chart-canvas-wide">
-                <Line data={wellbeingChart.data} options={wellbeingChart.options} />
+                <Suspense fallback={<p className="hint">Loading chart…</p>}>
+                  <WellbeingChart data={wellbeingChart.data} options={wellbeingChart.options} />
+                </Suspense>
               </div>
             ) : (
               <p className="hint">


### PR DESCRIPTION
## Why

Frontend `index.js` was 1.27 MB raw / 295 kB gzip. `chart.js` + `react-chartjs-2` + `chartjs-adapter-date-fns` made up ~208 kB / ~68 kB gzip of that, and the chart only renders on `/dashboard` when there is visible data — yet every page paid the download cost on first load.

## What

Extracted the chart-specific code into `frontend/src/app/WellbeingChart.tsx`:

- chart.js imports + `ChartJS.register(...)`
- `WellbeingChartView` type
- A default-export `WellbeingChart` component that wraps `<Line>`

Loaded it from `screens.tsx` via `React.lazy(() => import("./WellbeingChart"))` and wrapped the render in `<Suspense fallback={...}>`. Type-only import keeps `WellbeingChartView` accessible without dragging chart.js into the main chunk.

## Bundle impact

| Chunk | Before | After |
|---|---:|---:|
| `index.js`        | 1,272.68 kB / 295.30 kB gz | **1,064.13 kB / 227.24 kB gz** |
| `WellbeingChart.js` | — | 208.30 kB / 67.48 kB gz (lazy) |

Net: same total bytes shipped, but the chart chunk is deferred until the dashboard actually needs to draw — so first paint on `/login`, `/settings`, `/diary`, etc. is ~68 kB gzip lighter.

## Test plan

- [x] `bun run build` — clean
- [x] `bun run test` — 50/50 pass
- [x] `bun run lint` — clean
- [x] Local preview (`bun run dev`) — app boots, login screen renders, no console errors
- [ ] Smoke test after merge: log in, hit dashboard, confirm chart still draws (and watch network panel show the lazy chunk load)

Co-authored-by: Claude <noreply@anthropic.com>