### PR TITLE
ci: harden dependabot workflows from CodeRabbit review

### DIFF
--- a/.github/workflows/claude-pr-review-dependabot.yml
+++ b/.github/workflows/claude-pr-review-dependabot.yml
@@ -10,14 +10,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Default to read-only. Per-job permissions widen scope only where needed.
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
-  actions: read
-  checks: read
-  statuses: read
-  id-token: write
 
 concurrency:
   group: claude-pr-review-dependabot-${{ github.event.pull_request.number }}
@@ -25,8 +20,15 @@ concurrency:
 
 jobs:
   review:
+    name: Review dependabot CI failures
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # post the review
+      actions: read         # gh run view --log-failed
+      checks: read          # gh pr checks
+      statuses: read
     steps:
       - name: Wait for CI to complete
         id: wait
@@ -43,6 +45,7 @@ jobs:
           merge_excl="Dependabot auto-merge"
           deadline=$(( $(date +%s) + 1800 ))
           checks="[]"
+          pending="0"
           while [ "$(date +%s)" -lt "$deadline" ]; do
             checks="$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket,workflow 2>/dev/null || echo '[]')"
             pending=$(jq --arg a "$self_excl" --arg b "$merge_excl" \
@@ -60,6 +63,14 @@ jobs:
             fi
             sleep 30
           done
+
+          # Treat polling timeout as failure: a still-pending check after 30 min
+          # is a real symptom worth surfacing, not a silent pass.
+          if [ "$pending" != "0" ]; then
+            echo "Timed out waiting for CI to complete (still pending: $pending)."
+            echo "ci_state=failure" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           fails=$(jq --arg a "$self_excl" --arg b "$merge_excl" \
             '[.[] | select((.workflow // "") != $a and (.workflow // "") != $b and (.bucket == "fail" or .bucket == "cancel"))] | length' \
@@ -106,14 +117,15 @@ jobs:
 
       - name: Checkout default branch (NOT the PR head)
         if: steps.prepare.outputs.should_run == 'true'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Claude PR review
         if: steps.prepare.outputs.should_run == 'true'
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1.0.132
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,9 +4,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Default to read-only. Per-job permissions widen scope only where needed.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: dependabot-automerge-${{ github.event.pull_request.number }}
@@ -14,12 +14,16 @@ concurrency:
 
 jobs:
   merge:
+    name: Auto-merge Dependabot updates
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # squash merge writes to the default branch
+      pull-requests: write  # enable auto-merge on the PR
     steps:
       - name: Fetch dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Apply hardening suggestions from CodeRabbit review of the original switch-to-pull_request_target PR.

- Permissions default to contents: read at workflow level, widened per-job only where actually needed (remove unused issues/id-token).
- Polling timeout now treated as CI failure (was silent pass).
- Checkout pinned to actions/checkout@v4 SHA with persist-credentials: false.
- dependabot/fetch-metadata bumped to v3.1.0 + job name added.