### PR TITLE
fix: replace wget healthcheck with bun fetch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./data:/app/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:5555/api/v1/auth/session"]
+      test: ["CMD", "bun", "--eval", "const r=await fetch('http://localhost:5555/api/v1/auth/session');process.exit(r.ok?0:1)"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Compose healthcheck used `wget`, but image `oven/bun:1` has no wget binary
- Container reported `unhealthy` (failing streak 1900+)
- Switch healthcheck to `bun --eval` + `fetch()`, matching the pattern already used in the mymoney Dockerfile

## Test plan
- [x] `docker compose up -d health` — container reports `healthy` within 30s
- [x] `docker ps --filter health=unhealthy` returns no rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)