### PR TITLE
docs: Android conversion design docs + dir scaffolding

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,28 @@
+# android/
+
+Placeholder for the Android client of Health.
+
+**Status**: not implemented yet. Approach decision pending — see
+[`docs/android/`](../docs/android/) for the comparison of options and
+the criteria that will drive the choice.
+
+When implementation starts, this directory will hold either:
+
+- a full **Kotlin + Jetpack Compose** Android Studio project, or
+- a **Capacitor** wrapper around the existing `frontend/`, or
+- whatever else the decision in `docs/android/03-decision.md` lands on.
+
+## Opening in Android Studio
+
+Once code lives here, open Android Studio at this folder (not at the
+monorepo root) — Gradle expects `settings.gradle.kts` at the project
+root and gets confused by sibling `node_modules/`.
+
+```
+File → Open → /home/luca/github/apps/health/android
+```
+
+## Talking to the backend
+
+The Android client talks to the same backend that powers `frontend/`.
+Shared API types and generated clients live in [`../shared/`](../shared/).

--- a/docs/android/01-approaches.md
+++ b/docs/android/01-approaches.md
@@ -1,0 +1,119 @@
+# Android conversion — approaches
+
+Five candidate paths for delivering Health on Android. Ordered by
+effort, low → high.
+
+## A. TWA / PWA wrapper
+
+Wrap the existing PWA in a Trusted Web Activity. The "app" is a
+fullscreen Chrome tab signed by the developer. Generated with
+[Bubblewrap](https://github.com/GoogleChromeLabs/bubblewrap).
+
+- **Effort**: 1–2 days, mostly icon and signing setup.
+- **Reuse**: 100% of `frontend/`. No new UI code.
+- **Native APIs**: only what the browser exposes (Web Bluetooth,
+  Notifications API, IndexedDB). No background work, no widgets.
+- **Distribution**: Play Store accepts TWAs but flags them as
+  PWA-backed.
+- **When this wins**: prove demand before investing more, or the web
+  app already feels native enough on mobile.
+- **When this loses**: anything offline-first, anything needing
+  Android-specific UI (Material You, predictive back gesture,
+  widgets, Wear OS).
+
+## B. Capacitor (hybrid)
+
+[Capacitor](https://capacitorjs.com/) bundles `frontend/` into a
+WebView shell with a plugin bridge for native APIs. Built APK
+contains the JS bundle plus a thin Kotlin host activity.
+
+- **Effort**: 1–3 weeks for a polished release including plugin work
+  and store assets.
+- **Reuse**: ~90% of `frontend/`. shadcn/ui components keep working
+  because they are still rendered by Chromium.
+- **Native APIs**: any, through Capacitor plugins
+  (`@capacitor/camera`, `@capacitor/biometric-auth`, etc.) or custom
+  Kotlin plugin code.
+- **Performance**: scrolling and animations feel "close to native"
+  on modern Android (WebView is Chromium 110+). Heavy lists or
+  custom gestures still show their roots.
+- **Bundle size**: 8–25 MB.
+- **When this wins**: time to first install matters, design system
+  is already in `frontend/`, the app is form/list/chart shaped.
+- **When this loses**: complex gestures, 120 Hz animation goals,
+  battery-sensitive background features.
+
+## C. React Native
+
+Rewrite the UI in React Native. Logic and TypeScript types can be
+factored out of `frontend/` into a shared package; the UI layer is
+new.
+
+- **Effort**: 4–8 weeks for feature parity.
+- **Reuse**: 30–50% (business logic, validation, API client). Zero UI
+  reuse — shadcn/ui is web-only.
+- **Native APIs**: full access via native modules, ecosystem mature.
+- **Cross-platform**: same code targets iOS later.
+- **When this wins**: iOS is a near-term goal, the team prefers JS,
+  there is appetite to maintain a parallel UI codebase.
+- **When this loses**: solo developer who doesn't already own RN
+  tooling — the surface area is large.
+
+## D. Compose Multiplatform
+
+Kotlin + Compose UI shared across Android, iOS, desktop, and (beta)
+web. Backend stays as is.
+
+- **Effort**: 3–8 weeks, with a learning ramp on Compose if new to
+  it.
+- **Reuse**: nothing from `frontend/`. UI is rewritten in Compose.
+- **Native APIs**: full on Android, growing on iOS, mature on
+  desktop.
+- **Cross-platform**: single Compose UI on multiple targets.
+- **When this wins**: future-proofing, Kotlin-first stack, more
+  than one mobile target planned.
+- **When this loses**: still maturing on iOS web targets, library
+  ecosystem thinner than RN or native, learning cost if Compose is
+  new.
+
+## E. Native Kotlin + Jetpack Compose
+
+Fresh Android app. Compose UI, Retrofit/Ktor for HTTP, Room or
+DataStore for local persistence, talking to the existing backend.
+
+- **Effort**: 4–12 weeks depending on familiarity with Compose.
+- **Reuse**: API contract only. UI is built from scratch.
+- **Native APIs**: full. Material You, predictive back, edge-to-edge
+  insets, widgets via Glance, Wear OS later — all gratis.
+- **Performance**: best of the bunch. 60–120 fps, lowest RAM, lowest
+  battery, smallest APK.
+- **When this wins**: long-term Android-first product, the dev
+  wants to actually learn Android, polish matters.
+- **When this loses**: time to first store release matters more than
+  fit and finish.
+
+## Side-by-side
+
+| Dimension | TWA | Capacitor | RN | Compose MP | Native Kotlin |
+|-----------|-----|-----------|----|------------|---------------|
+| Effort to v1 | 1–2 d | 1–3 w | 4–8 w | 3–8 w | 4–12 w |
+| `frontend/` reuse | 100% | ~90% | 30–50% | 0% | 0% |
+| Native API access | minimal | via plugins | full | full | full |
+| Cold start | 1.5–3 s | 0.8–2 s | 0.5–1 s | 0.3–0.8 s | 0.2–0.5 s |
+| APK size | 1–2 MB | 8–25 MB | 15–30 MB | 5–15 MB | 3–10 MB |
+| 60+ fps UI | flaky | yes-ish | yes | yes | yes |
+| Material You theming | no | manual | manual | yes | yes (gratis) |
+| Offline-first ergonomics | poor | ok | good | good | best |
+| Long-term maintenance cost | low | low–med | med | med | med–high |
+| Learning value (this repo) | low | low | medium | high | high |
+
+## Cross-cutting notes
+
+- All five paths can share `backend/` unchanged. The HTTP API is the
+  single contract.
+- Whatever path is chosen, an OpenAPI spec in `shared/` plus a code
+  generator removes drift between web and Android clients. This is
+  worth doing even before the Android implementation lands.
+- Distribution effort (Play Store account, signing keys, store
+  listing, screenshots) is the same regardless of approach. Budget a
+  few days on top of the technical estimate.

--- a/docs/android/02-monorepo-layout.md
+++ b/docs/android/02-monorepo-layout.md
@@ -1,0 +1,115 @@
+# Android conversion — monorepo layout
+
+Adding Android does not change the repo strategy: **monorepo stays**.
+This doc captures the proposed layout and the reasoning, so the
+choice is reviewable and reversible.
+
+## Proposed top-level layout
+
+```
+health/
+├── backend/                Bun + SQLite, unchanged
+├── frontend/               React + Vite + shadcn/ui, unchanged
+├── android/                NEW — Android client (approach TBD)
+├── shared/                 NEW — API contract + codegen scripts
+├── docs/
+│   ├── android/            this folder
+│   └── superpowers/        existing
+├── scripts/                existing repo-wide scripts
+├── tests/                  Playwright e2e against frontend+backend
+├── docker-compose.yml      backend+frontend only
+├── package.json            bun workspace root
+├── AGENTS.md, CLAUDE.md    cross-cutting rules
+└── README.md
+```
+
+Only two new top-level directories: `android/` and `shared/`. The
+existing tree is untouched.
+
+## Why monorepo (for this project)
+
+- **Solo developer**: cross-stack refactors land as one PR. No tag
+  juggling between repos.
+- **API contract churns**: every endpoint change has to land in
+  backend, then frontend, then Android. Single PR keeps them in
+  sync; separate repos invite drift.
+- **CI cost**: a single workflow file per stack with `paths:` filters
+  beats coordinating runs across repos.
+- **Discoverability**: one clone gives the whole picture.
+
+The usual monorepo objections do not apply here:
+
+- *Repo gets huge* — current repo is small, even with `android/`
+  it's well under 500 MB.
+- *Tooling mismatch* — Gradle and Bun coexist because they don't
+  talk to each other. Android Studio opens `android/` as its project
+  root and ignores everything above.
+- *CI scope* — `.github/workflows/*` with path filters scopes each
+  job to what changed.
+
+## When to split (future trigger)
+
+Move `android/` to its own repo if:
+
+- a separate team owns Android with its own release cadence,
+- `shared/` graduates to a public npm + maven package that external
+  consumers depend on (then the package needs its own repo for clean
+  semver and a focused README),
+- the repo grows past ~5 GB or `git status` starts taking seconds.
+
+None of these are close.
+
+## How `android/` integrates
+
+- Gradle wrapper (`gradlew`) lives inside `android/`. Build commands
+  always run from there: `cd android && ./gradlew assembleDebug`.
+- Android Studio opens `android/` as the project root, not the repo
+  root. Open `health/android` from the welcome screen, not `health/`.
+- Add to `android/.gitignore`: `.gradle/`, `build/`, `local.properties`,
+  `*.iml`, `.idea/` — the usual Android list.
+
+## How `shared/` integrates
+
+Two halves:
+
+1. **`shared/openapi.yaml`** — single source of truth for the HTTP
+   API. Either hand-written or emitted by the backend at build time
+   (preferred: drift-free).
+2. **`shared/scripts/`** — one script per client target:
+   - `gen-ts-client.sh` → writes typed fetch client into
+     `frontend/src/api/`.
+   - `gen-kotlin-client.sh` → writes Retrofit interfaces and Kotlin
+     data classes into `android/app/src/main/java/.../api/`.
+
+Both scripts are idempotent. Re-running after a spec change updates
+the generated files; CI fails if generated output drifts from
+committed output.
+
+## CI changes implied by the layout
+
+New workflow `android-ci.yml`, triggered by:
+
+```yaml
+on:
+  push:
+    paths:
+      - 'android/**'
+      - 'shared/openapi.yaml'
+      - '.github/workflows/android-ci.yml'
+```
+
+Jobs: `./gradlew :app:assembleDebug :app:testDebugUnitTest
+:app:lintDebug`. Gradle caches keyed on `gradle/libs.versions.toml`
+and wrapper checksum.
+
+Existing `backend` and `frontend` workflows stay untouched.
+
+## Files added by this design
+
+Only documentation and placeholders so far. No Gradle, no Kotlin, no
+generated clients — those land when the approach in `03-decision.md`
+is chosen.
+
+- `android/README.md`     — placeholder explaining what goes here
+- `shared/README.md`      — placeholder explaining the contract folder
+- `docs/android/*.md`     — these design docs

--- a/docs/android/03-decision.md
+++ b/docs/android/03-decision.md
@@ -1,0 +1,78 @@
+# Android conversion — decision
+
+No decision yet. This file records the criteria the decision will be
+made against and the current leaning, so the next pass can either
+commit or revise.
+
+## Criteria, ranked
+
+1. **Learning value for the maintainer.** This project doubles as a
+   way to learn Android. Approaches that teach more — native Kotlin,
+   Compose — score higher even at a cost in time.
+2. **Time to a usable v1.** "Usable" = installable APK, login,
+   record an entry, view history. Not store-ready.
+3. **Long-term maintenance cost for a solo developer.** Two parallel
+   UI codebases (RN, Compose Multiplatform if web is also a target)
+   cost more than one.
+4. **UX fit and polish ceiling.** Material You, gestures, widgets,
+   notifications. Anything the browser cannot reach is a permanent
+   ceiling for TWA and a soft ceiling for Capacitor.
+5. **Reusability of `frontend/`**. High reuse means changes to the
+   web app come along for free; low reuse means two UIs to keep
+   feature-parity.
+
+## How each approach scores
+
+Score: ✓ good fit, ~ partial, ✗ poor fit.
+
+| Approach | Learning | TTV v1 | Maint. | UX ceiling | Reuse |
+|----------|----------|--------|--------|------------|-------|
+| TWA | ✗ | ✓ | ✓ | ✗ | ✓ |
+| Capacitor | ~ | ✓ | ✓ | ~ | ✓ |
+| React Native | ~ | ~ | ~ | ✓ | ~ |
+| Compose Multiplatform | ✓ | ~ | ~ | ✓ | ✗ |
+| Native Kotlin + Compose | ✓ | ✗ | ~ | ✓ | ✗ |
+
+## Current leaning: native Kotlin + Compose (E)
+
+Reasons:
+
+- Criterion 1 (learning) dominates. The user has explicitly said they
+  want to learn Android, and the other approaches either skip Android
+  entirely (TWA, Capacitor) or teach a layer on top of it (RN,
+  Compose Multiplatform).
+- Solo dev means cross-platform abstractions (RN, Compose MP) cost
+  more than they save: there is no iOS team in the picture.
+- The web app is small enough that two UI codebases is sustainable.
+- Capacitor remains the fallback if priorities flip toward
+  time-to-store.
+
+## What needs to happen before deciding
+
+- [ ] Confirm with the user that learning is the top criterion (not
+      time-to-store).
+- [ ] Confirm there is no near-term iOS plan. If iOS lands within
+      ~6 months, reconsider RN or Compose Multiplatform.
+- [ ] Sketch the v1 feature list. If it grows past "auth + CRUD +
+      one chart," Capacitor's reuse advantage gets bigger.
+- [ ] Decide whether `shared/openapi.yaml` is hand-written or
+      backend-emitted. This decision is independent of approach but
+      blocks the codegen scripts.
+
+## Reversibility
+
+The approach is reversible at low cost while `android/` is empty.
+After a few weeks of Kotlin code, a switch to Capacitor means
+discarding the UI work — backend and `shared/` stay intact either
+way. The point of no return is roughly "first beta release".
+
+## Open questions
+
+- Where will the Android app fetch the backend? Localhost for dev is
+  obvious; for production, does the app point at a single hosted
+  instance or is it self-hosted per-user?
+- Auth: does the existing web auth (session cookie?) translate
+  cleanly to a mobile client, or does Android need bearer tokens
+  with refresh?
+- Push notifications: in scope for v1 or later? FCM setup is its own
+  multi-day side quest.

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -1,0 +1,30 @@
+# Android conversion — design docs
+
+This folder collects the analysis behind bringing Health to Android.
+No code yet. The goal of these docs is to make the eventual decision
+explicit and reviewable.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| [`01-approaches.md`](./01-approaches.md) | Five candidate approaches, side-by-side comparison |
+| [`02-monorepo-layout.md`](./02-monorepo-layout.md) | How the Android subproject fits into this repo |
+| [`03-decision.md`](./03-decision.md) | Criteria that will pick the approach + current standing |
+
+## TL;DR
+
+- The web app (`backend/` + `frontend/`) stays as is.
+- The Android client will reuse the backend over HTTP; UI is the only
+  thing being rebuilt or wrapped.
+- Five paths considered: TWA, Capacitor, React Native, Compose
+  Multiplatform, native Kotlin/Compose.
+- Default leaning: **native Kotlin/Compose**, because the project is
+  also a learning vehicle for Android and the team is one person.
+  Capacitor is the fast-ship alternative if priorities shift to
+  time-to-store.
+- Monorepo, not split repos. New top-level dirs: `android/` and
+  `shared/`.
+
+Read `03-decision.md` for the criteria and `01-approaches.md` for the
+trade-off matrix.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,40 @@
+# shared/
+
+Cross-stack assets that need a single source of truth across
+`backend/`, `frontend/`, and (future) `android/`.
+
+**Status**: scaffolded, not populated. This directory exists so the
+Android exploration documented in [`../docs/android/`](../docs/android/)
+has a concrete place to point at when discussing client code
+generation.
+
+## What belongs here
+
+- **API contract** (`openapi.yaml` or similar): the spec the backend
+  serves and that frontend + Android consume. Hand-written or
+  generated from `backend/` route definitions.
+- **Generator scripts** (`scripts/`): one per client target
+  (TypeScript for `frontend/`, Kotlin/Retrofit for `android/`).
+- **Shared docs** about the contract — versioning policy, breaking
+  change rules, deprecation flow.
+
+## What does NOT belong here
+
+- Runtime code of any kind. This directory is build-time inputs and
+  generated outputs only.
+- Per-stack utilities — those live in the respective `backend/src/`,
+  `frontend/src/`, `android/app/src/`.
+- Secrets, environment files, deploy config.
+
+## Why a shared folder at all
+
+Single source of truth for API shapes means:
+
+- one place to update when an endpoint changes,
+- generated clients keep `frontend/` and `android/` in lockstep,
+- breaking changes surface at build time in every consumer, not at
+  runtime in production.
+
+If only one client ever existed there would be no point. The moment a
+second client (the Android app) lands, drift becomes a real risk and
+this directory pays for itself.


### PR DESCRIPTION
## Summary

Adds the design analysis for bringing Health to Android, plus two
top-level placeholder dirs. **No application code** — docs and READMEs
only.

## What changed

- `docs/android/` — four design docs:
  - `01-approaches.md`: five candidate paths (TWA, Capacitor, React
    Native, Compose Multiplatform, native Kotlin) with a side-by-side
    trade-off matrix.
  - `02-monorepo-layout.md`: how `android/` + `shared/` fit the repo,
    why monorepo stays, implied CI changes.
  - `03-decision.md`: ranked criteria + current leaning (native
    Kotlin/Compose, learning value first; Capacitor as fallback).
  - `README.md`: TL;DR index.
- `android/README.md`, `shared/README.md` — placeholders marking where
  the future client and the API-contract/codegen folder will live.

## Why

Make the approach decision explicit and reviewable before writing any
Kotlin. `shared/` (OpenAPI contract + codegen) is worth scaffolding now
because client drift becomes real the moment a second client exists.

## Reviewer notes

- Docs only: no Gradle, no Kotlin, no generated clients, no workflow
  changes. Existing backend/frontend untouched.
- `03-decision.md` still has open questions (iOS timeline, auth model,
  push) — intentional; this PR records the analysis, not a locked call.