### PR TITLE
fix(docker): make COOKIE_SECURE overridable via env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PORT: 5555
       DB_PATH: /app/data/health.sqlite
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5555,http://127.0.0.1:5555,http://localhost:5173,http://127.0.0.1:5173}
-      COOKIE_SECURE: "true"
+      COOKIE_SECURE: ${COOKIE_SECURE:-true}
     volumes:
       - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- `COOKIE_SECURE` was hardcoded to `"true"` in `docker-compose.yml`, so the session cookie always carried the `Secure` flag.
- On the personal server the app is reached over plain HTTP (`http://192.168.1.6:5555` / Tailscale IP) — browsers silently drop `Secure` cookies on non-HTTPS origins, so login succeeded server-side but the session never persisted ("can't get past login").
- Now reads `${COOKIE_SECURE:-true}`: secure-by-default for HTTPS deploys, overridable via `.env` for the HTTP LAN deploy. Matches the existing `ALLOWED_ORIGINS` pattern in the same file.

## Test plan
- [ ] CI green
- [ ] On server: set `COOKIE_SECURE=false` in `.env`, `git pull`, `docker compose up -d`
- [ ] `docker inspect health` shows `COOKIE_SECURE=false`
- [ ] Browser login over HTTP persists the session