### PR TITLE
feat: per-medicine preselection + Preferences settings tab

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -20,7 +20,7 @@ function tableExists(db: SQLiteDB, tableName: string): boolean {
   return Boolean(row?.name);
 }
 
-const ALLOWED_TABLE_NAMES = new Set(["diary_entries", "pain_entries", "user_preferences"]);
+const ALLOWED_TABLE_NAMES = new Set(["diary_entries", "pain_entries", "user_preferences", "pain_options"]);
 
 function columnExists(db: SQLiteDB, tableName: string, columnName: string): boolean {
   if (!ALLOWED_TABLE_NAMES.has(tableName)) {
@@ -51,6 +51,12 @@ function ensurePainColumns(db: SQLiteDB): void {
 function ensureUserPreferenceColumns(db: SQLiteDB): void {
   if (!columnExists(db, "user_preferences", "birthday")) {
     db.exec(`ALTER TABLE user_preferences ADD COLUMN birthday TEXT`);
+  }
+}
+
+function ensurePainOptionColumns(db: SQLiteDB): void {
+  if (!columnExists(db, "pain_options", "preselected")) {
+    db.exec(`ALTER TABLE pain_options ADD COLUMN preselected INTEGER NOT NULL DEFAULT 1`);
   }
 }
 
@@ -151,6 +157,7 @@ export function runMigrations(db: SQLiteDB): void {
     ensurePainColumns(db);
     ensureMoodColumns(db);
     ensureUserPreferenceColumns(db);
+    ensurePainOptionColumns(db);
     backfillPainColumnsFromLegacyTags(db);
     dropLegacyPainTables(db);
     backfillFtsTables(db);

--- a/backend/src/db/drizzle-schema.ts
+++ b/backend/src/db/drizzle-schema.ts
@@ -164,6 +164,7 @@ export const painOptions = sqliteTable("pain_options", {
   userId: integer("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
   field: text("field").notNull(),
   value: text("value").notNull(),
+  preselected: integer("preselected").notNull().default(1),
 });
 
 export const moodOptions = sqliteTable("mood_options", {

--- a/backend/src/routes/backup.test.ts
+++ b/backend/src/routes/backup.test.ts
@@ -145,6 +145,69 @@ describe("POST /backup/json/import", () => {
   });
 });
 
+describe("backup medicine preselection round-trip", () => {
+  async function restoreMedicine(app: Awaited<ReturnType<typeof setup>>["app"], cookie: string, value: string) {
+    await app.request("/pain/options/restore", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value }),
+    });
+  }
+
+  test("export includes preselectedMedicines reflecting current state", async () => {
+    const { app, cookie } = await setup();
+    await restoreMedicine(app, cookie, "200mg celebrex");
+    await restoreMedicine(app, cookie, "4mg sirdalud");
+    // Turn one off so the export must distinguish preselected from the full list.
+    await app.request("/pain/options/preselect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value: "4mg sirdalud", preselected: false }),
+    });
+
+    const body = await (await app.request("/backup/json", { headers: { cookie } })).json();
+    expect(body.data.pain.options.options.medicines).toEqual(["200mg celebrex", "4mg sirdalud"]);
+    expect(body.data.pain.options.preselectedMedicines).toEqual(["200mg celebrex"]);
+  });
+
+  test("import restores options list and preselection", async () => {
+    const { app, cookie } = await setup();
+    const res = await app.request("/backup/json/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({
+        pain: {
+          rows: [],
+          options: {
+            options: { medicines: ["aspirin", "ibuprofen", "paracetamol"] },
+            preselectedMedicines: ["ibuprofen"],
+          },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const opts = await (await app.request("/pain/options", { headers: { cookie } })).json();
+    expect(opts.data.medicines).toEqual(["aspirin", "ibuprofen", "paracetamol"]);
+    expect(opts.data.preselectedMedicines).toEqual(["ibuprofen"]);
+  });
+
+  test("legacy import without preselectedMedicines defaults medicines to preselected", async () => {
+    const { app, cookie } = await setup();
+    const res = await app.request("/backup/json/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({
+        pain: { rows: [], options: { options: { medicines: ["aspirin", "ibuprofen"] } } },
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const opts = await (await app.request("/pain/options", { headers: { cookie } })).json();
+    expect(opts.data.preselectedMedicines).toEqual(["aspirin", "ibuprofen"]);
+  });
+});
+
 describe("POST /backup/xlsx/import", () => {
   test("rejects multipart without 'file' field with 400", async () => {
     const { app, cookie } = await setup();

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -15,7 +15,7 @@ import {
 } from "../helpers.ts";
 import { backupImportSchema, prefsSchema, DEFAULT_MODEL } from "../schemas.ts";
 import { requireAuth } from "../middleware/auth.ts";
-import { loadPainOptionsForUser } from "./pain.ts";
+import { loadPainOptionsForUser, loadPreselectedMedicines } from "./pain.ts";
 import { loadMoodOptionsForUser } from "./mood.ts";
 
 type Env = { Variables: { db: DrizzleDB; rawDb: SQLiteDB; userId: number; userEmail: string; sessionSid: string } };
@@ -109,7 +109,14 @@ backup.get("/json", (c) => {
   return c.json({
     data: {
       diary: { ...result.diary, moodOptions: loadMoodOptionsForUser(db, userId) },
-      pain: { ...result.pain, options: { options: loadPainOptionsForUser(db, userId), removed: removedMap } },
+      pain: {
+        ...result.pain,
+        options: {
+          options: loadPainOptionsForUser(db, userId),
+          removed: removedMap,
+          preselectedMedicines: loadPreselectedMedicines(db, userId),
+        },
+      },
       prefs: {
         model: prefs?.model ?? DEFAULT_MODEL,
         chatRange: prefs?.chatRange ?? "all",
@@ -199,6 +206,34 @@ backup.post("/json/import", async (c) => {
           const normalized = String(raw).trim();
           if (!normalized) continue;
           insertRemoved.run(userId, field, normalized);
+        }
+      }
+    }
+
+    // Restore the pain options list and medicine preselection. Guarded on the
+    // options block being present so legacy backups (which omit it) leave the
+    // user's existing options untouched. When preselectedMedicines is absent
+    // (pre-feature backups), medicines default to preselected (column default).
+    const importedOptions = body.pain?.options?.options;
+    if (importedOptions && typeof importedOptions === "object") {
+      rawDb.query(`DELETE FROM pain_options WHERE user_id = ?`).run(userId);
+      const rawPreselected = body.pain?.options?.preselectedMedicines;
+      const preselectedSet = Array.isArray(rawPreselected)
+        ? new Set(rawPreselected.map((v) => String(v).trim()))
+        : null;
+      const insertOption = rawDb.query(
+        `INSERT INTO pain_options (user_id, field, value, preselected)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(user_id, field, value) DO NOTHING`
+      );
+      for (const field of PAIN_MULTI_FIELDS) {
+        const values = (importedOptions as any)[field];
+        if (!Array.isArray(values)) continue;
+        for (const raw of values) {
+          const normalized = String(raw).trim();
+          if (!normalized) continue;
+          const preselected = field === "medicines" && preselectedSet ? (preselectedSet.has(normalized) ? 1 : 0) : 1;
+          insertOption.run(userId, field, normalized, preselected);
         }
       }
     }

--- a/backend/src/routes/pain.test.ts
+++ b/backend/src/routes/pain.test.ts
@@ -270,6 +270,7 @@ describe("pain options routes", () => {
       medicines: [],
       habits: [],
       other: [],
+      preselectedMedicines: [],
     });
   });
 
@@ -316,5 +317,57 @@ describe("pain options routes", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error.code).toBe("INVALID_VALUE");
+  });
+
+  test("restored medicine is preselected by default", async () => {
+    const { app, cookie } = await setup();
+    await app.request("/pain/options/restore", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value: "200mg celebrex" }),
+    });
+    const opts = await (await app.request("/pain/options", { headers: { cookie } })).json();
+    expect(opts.data.medicines).toEqual(["200mg celebrex"]);
+    expect(opts.data.preselectedMedicines).toEqual(["200mg celebrex"]);
+  });
+
+  test("POST /options/preselect toggles preselection, GET reflects", async () => {
+    const { app, cookie } = await setup();
+    await app.request("/pain/options/restore", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value: "4mg sirdalud" }),
+    });
+
+    const off = await app.request("/pain/options/preselect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value: "4mg sirdalud", preselected: false }),
+    });
+    expect(off.status).toBe(200);
+    let opts = await (await app.request("/pain/options", { headers: { cookie } })).json();
+    expect(opts.data.medicines).toEqual(["4mg sirdalud"]);
+    expect(opts.data.preselectedMedicines).toEqual([]);
+
+    const on = await app.request("/pain/options/preselect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "medicines", value: "4mg sirdalud", preselected: true }),
+    });
+    expect(on.status).toBe(200);
+    opts = await (await app.request("/pain/options", { headers: { cookie } })).json();
+    expect(opts.data.preselectedMedicines).toEqual(["4mg sirdalud"]);
+  });
+
+  test("POST /options/preselect rejects unknown field 400", async () => {
+    const { app, cookie } = await setup();
+    const res = await app.request("/pain/options/preselect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "not_a_field", value: "x", preselected: true }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_FIELD");
   });
 });

--- a/backend/src/routes/pain.test.ts
+++ b/backend/src/routes/pain.test.ts
@@ -370,4 +370,16 @@ describe("pain options routes", () => {
     const body = await res.json();
     expect(body.error.code).toBe("INVALID_FIELD");
   });
+
+  test("POST /options/preselect rejects non-medicines field 400", async () => {
+    const { app, cookie } = await setup();
+    const res = await app.request("/pain/options/preselect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", cookie },
+      body: JSON.stringify({ field: "area", value: "back", preselected: true }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_FIELD");
+  });
 });

--- a/backend/src/routes/pain.ts
+++ b/backend/src/routes/pain.ts
@@ -76,8 +76,8 @@ pain.post("/options/preselect", async (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
   const body = await parseJson(c, optionPreselectSchema);
-  if (!PAIN_MULTI_FIELDS.includes(body.field as PainMultiField)) {
-    return c.json({ error: { code: "INVALID_FIELD", message: "Unknown pain field" } }, 400);
+  if (body.field !== "medicines") {
+    return c.json({ error: { code: "INVALID_FIELD", message: "Preselection is only supported for medicines" } }, 400);
   }
   const normalizedValue = body.value.trim();
   if (!normalizedValue) {

--- a/backend/src/routes/pain.ts
+++ b/backend/src/routes/pain.ts
@@ -15,7 +15,7 @@ import {
   emptyPainTags,
   painRowToApi
 } from "../helpers.ts";
-import { painSchema, optionFieldSchema } from "../schemas.ts";
+import { painSchema, optionFieldSchema, optionPreselectSchema } from "../schemas.ts";
 import { requireAuth } from "../middleware/auth.ts";
 
 type Env = { Variables: { db: DrizzleDB; rawDb: SQLiteDB; userId: number; userEmail: string; sessionSid: string } };
@@ -47,6 +47,16 @@ function loadPainOptionsForUser(db: DrizzleDB, userId: number): PainTagMap {
   return out;
 }
 
+function loadPreselectedMedicines(db: DrizzleDB, userId: number): string[] {
+  return db
+    .select({ value: painOptions.value })
+    .from(painOptions)
+    .where(and(eq(painOptions.userId, userId), eq(painOptions.field, "medicines"), eq(painOptions.preselected, 1)))
+    .orderBy(painOptions.id)
+    .all()
+    .map((row) => row.value);
+}
+
 const pain = new Hono<Env>();
 
 pain.use(requireAuth);
@@ -54,7 +64,30 @@ pain.use(requireAuth);
 pain.get("/options", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
-  return c.json({ data: loadPainOptionsForUser(db, userId) });
+  return c.json({
+    data: {
+      ...loadPainOptionsForUser(db, userId),
+      preselectedMedicines: loadPreselectedMedicines(db, userId),
+    },
+  });
+});
+
+pain.post("/options/preselect", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("userId");
+  const body = await parseJson(c, optionPreselectSchema);
+  if (!PAIN_MULTI_FIELDS.includes(body.field as PainMultiField)) {
+    return c.json({ error: { code: "INVALID_FIELD", message: "Unknown pain field" } }, 400);
+  }
+  const normalizedValue = body.value.trim();
+  if (!normalizedValue) {
+    return c.json({ error: { code: "INVALID_VALUE", message: "Value must not be empty" } }, 400);
+  }
+  db.update(painOptions)
+    .set({ preselected: body.preselected ? 1 : 0 })
+    .where(and(eq(painOptions.userId, userId), eq(painOptions.field, body.field), eq(painOptions.value, normalizedValue)))
+    .run();
+  return c.json({ data: { ok: true } });
 });
 
 pain.post("/options/remove", async (c) => {
@@ -177,5 +210,5 @@ pain.delete("/:id", (c) => {
   return c.json({ data: { ok: true } });
 });
 
-export { loadPainOptionsForUser };
+export { loadPainOptionsForUser, loadPreselectedMedicines };
 export default pain;

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 9;
+export const SCHEMA_VERSION = 10;
 
 export const migrationStatements: string[] = [
   `CREATE TABLE IF NOT EXISTS users (
@@ -89,9 +89,12 @@ export const migrationStatements: string[] = [
     user_id INTEGER NOT NULL,
     field TEXT NOT NULL,
     value TEXT NOT NULL,
+    preselected INTEGER NOT NULL DEFAULT 1,
     UNIQUE(user_id, field, value),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   )`,
+  // schema-v10: preselected column added to pain_options. ALTER TABLE for
+  // existing databases is handled separately in db.ts via columnExists guard.
   `CREATE TABLE IF NOT EXISTS mood_options (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -136,7 +136,8 @@ export const backupImportSchema = z.object({
       options: z
         .object({
           options: z.record(z.string(), z.array(z.string())).optional(),
-          removed: z.record(z.string(), z.array(z.string())).optional()
+          removed: z.record(z.string(), z.array(z.string())).optional(),
+          preselectedMedicines: z.array(z.string()).optional()
         })
         .optional()
     })
@@ -147,4 +148,10 @@ export const backupImportSchema = z.object({
 export const optionFieldSchema = z.object({
   field: z.string(),
   value: z.string().min(1)
+});
+
+export const optionPreselectSchema = z.object({
+  field: z.string(),
+  value: z.string().min(1),
+  preselected: z.boolean()
 });

--- a/frontend/src/app/MedicinePreselectionSection.tsx
+++ b/frontend/src/app/MedicinePreselectionSection.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiEnvelopeSchema, apiFetch, getErrorMessage } from "../lib";
+import { csvToList, listToCsv, painOptionsSchema } from "./core";
+import { InlineFeedback, MultiSelectField, SectionHead } from "./shared";
+
+/**
+ * Medicine preselection settings. Reuses the Pain/Diary pill selector
+ * (MultiSelectField) so the UX matches the rest of the app: a "selected"
+ * pill here means "preselected by default in a new pain entry". Queries pain
+ * options directly (shared cache with the Pain form) so the parent
+ * SettingsSection doesn't need to thread props.
+ */
+export function MedicinePreselectionSection({ enabled }: { enabled: boolean }) {
+  const queryClient = useQueryClient();
+
+  const optionsQuery = useQuery({
+    queryKey: ["pain-options"],
+    enabled,
+    queryFn: async () => apiFetch("/api/v1/pain/options", { method: "GET" }, (raw) => painOptionsSchema.parse(raw).data),
+  });
+
+  const medicines = optionsQuery.data?.medicines ?? [];
+  const preselectedCsv = listToCsv(optionsQuery.data?.preselectedMedicines ?? []);
+
+  const [value, setValue] = useState(preselectedCsv);
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setValue(preselectedCsv); }, [preselectedCsv]);
+
+  const preselectMutation = useMutation({
+    mutationFn: async (vars: { value: string; preselected: boolean }) =>
+      apiFetch(
+        "/api/v1/pain/options/preselect",
+        { method: "POST", body: JSON.stringify({ field: "medicines", value: vars.value, preselected: vars.preselected }) },
+        (raw) => apiEnvelopeSchema(z.object({ ok: z.boolean() })).parse(raw).data,
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["pain-options"] });
+    },
+  });
+
+  const handleChange = (next: string) => {
+    const prev = csvToList(value);
+    const prevSet = new Set(prev.map((medicine) => medicine.toLowerCase()));
+    const nextList = csvToList(next);
+    const nextSet = new Set(nextList.map((medicine) => medicine.toLowerCase()));
+    setValue(next);
+    for (const medicine of nextList) {
+      if (!prevSet.has(medicine.toLowerCase())) preselectMutation.mutate({ value: medicine, preselected: true });
+    }
+    for (const medicine of prev) {
+      if (!nextSet.has(medicine.toLowerCase())) preselectMutation.mutate({ value: medicine, preselected: false });
+    }
+  };
+
+  return (
+    <div className="stack">
+      <SectionHead title="Medicine preselection" ruled />
+      <p className="hint">Choose which medicines start already selected when you log a new pain entry.</p>
+      {optionsQuery.isLoading ? (
+        <p className="hint">Loading…</p>
+      ) : (
+        <MultiSelectField hideLabel label="Medicines" fieldKey="medicines" value={value} options={medicines} onChange={handleChange} />
+      )}
+      <InlineFeedback message={preselectMutation.error ? { tone: "error", text: getErrorMessage(preselectMutation.error) } : null} />
+    </div>
+  );
+}

--- a/frontend/src/app/core.ts
+++ b/frontend/src/app/core.ts
@@ -166,6 +166,7 @@ export const painOptionsSchema = apiEnvelopeSchema(
     medicines: z.array(z.string()),
     habits: z.array(z.string()),
     other: z.array(z.string()),
+    preselectedMedicines: z.array(z.string()),
   }),
 );
 

--- a/frontend/src/app/settings-mockups.tsx
+++ b/frontend/src/app/settings-mockups.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import type { InlineMessage } from "./core";
 import type { useAuth } from "../hooks/use-auth";
 import { getErrorMessage } from "../lib";
-import { InlineFeedback } from "./shared";
+import { InlineFeedback, SectionHead } from "./shared";
 import { McpAccessSection } from "./McpAccessSection";
+import { MedicinePreselectionSection } from "./MedicinePreselectionSection";
 
 type SettingsSectionProps = {
   auth: ReturnType<typeof useAuth>;
@@ -33,25 +34,19 @@ function BirthdayBlock({
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setValue(birthday ?? ""); }, [birthday]);
 
+  const handleChange = (next: string) => {
+    setValue(next);
+    onSaveBirthday(next || null);
+  };
+
   return (
-    <form
-      className="stack"
-      onSubmit={(event) => {
-        event.preventDefault();
-        onSaveBirthday(value || null);
-      }}
-    >
+    <div className="stack">
+      <SectionHead title="Birthday" ruled />
       <label className="field field-line">
-        <span className="field-line-label">Birthday</span>
-        <input type="date" aria-label="Birthday" value={value} onChange={(event) => setValue(event.target.value)} />
+        <input type="date" aria-label="Birthday" value={value} onChange={(event) => handleChange(event.target.value)} />
       </label>
-      <p className="hint">Why: this becomes locked birthday item in Giorni memorabili.</p>
-      <div className="save-section">
-        <button type="submit" className="btn btn-primary" disabled={birthdayPending}>
-          {birthdayPending ? "Saving..." : "Save birthday"}
-        </button>
-      </div>
-    </form>
+      <p className="hint">Why: this becomes a locked birthday item in Memorable days.{birthdayPending ? " Saving…" : ""}</p>
+    </div>
   );
 }
 
@@ -213,10 +208,10 @@ function AccountIdentity({ auth }: Pick<SettingsSectionProps, "auth">) {
 }
 
 /* ── Variant B — Sub-tabs ── */
-type SettingsTab = "account" | "birthday" | "backup" | "mcp" | "danger";
+type SettingsTab = "account" | "preferences" | "backup" | "mcp" | "danger";
 const settingsTabs: { id: SettingsTab; label: string; danger?: boolean }[] = [
   { id: "account", label: "Account" },
-  { id: "birthday", label: "Birthday" },
+  { id: "preferences", label: "Preferences" },
   { id: "backup", label: "Backup" },
   { id: "mcp", label: "MCP access" },
   { id: "danger", label: "Danger zone", danger: true },
@@ -241,12 +236,15 @@ export function SettingsVariantB(props: SettingsSectionProps) {
       </nav>
       <div className="settings-mock-panel">
         {tab === "account" ? <AccountBlock auth={props.auth} /> : null}
-        {tab === "birthday" ? (
-          <BirthdayBlock
-            birthday={props.birthday}
-            birthdayPending={props.birthdayPending}
-            onSaveBirthday={props.onSaveBirthday}
-          />
+        {tab === "preferences" ? (
+          <div className="stack">
+            <BirthdayBlock
+              birthday={props.birthday}
+              birthdayPending={props.birthdayPending}
+              onSaveBirthday={props.onSaveBirthday}
+            />
+            <MedicinePreselectionSection enabled />
+          </div>
         ) : null}
         {tab === "backup" ? (
           <BackupBlock

--- a/frontend/src/app/shared.tsx
+++ b/frontend/src/app/shared.tsx
@@ -232,37 +232,28 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
 
           return (
             <div key={option} className="multi-option-item">
-              <button
-                type="button"
-                className={isSelected ? "multi-option-chip active" : "multi-option-chip"}
-                tabIndex={editOptionsMode ? -1 : undefined}
-                onClick={() => {
-                  if (editOptionsMode) return;
-                  toggleOption(option);
-                }}
-                onKeyDown={(e) => {
-                  if (!editOptionsMode) return;
-                  if (e.key === " " || e.key === "Enter") {
-                    e.preventDefault();
-                  }
-                }}
-                aria-pressed={isSelected}
-              >
-                <span className="multi-option-label">{option}</span>
-                {editOptionsMode ? (
+              {editOptionsMode ? (
+                <div className={isSelected ? "multi-option-chip active" : "multi-option-chip"}>
+                  <span className="multi-option-label">{option}</span>
                   <button
                     type="button"
                     className="multi-option-remove"
                     aria-label={`Remove ${option} from suggestions`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setPendingRemovalKey(optionKey);
-                    }}
+                    onClick={() => setPendingRemovalKey(optionKey)}
                   >
                     ×
                   </button>
-                ) : null}
-              </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className={isSelected ? "multi-option-chip active" : "multi-option-chip"}
+                  onClick={() => toggleOption(option)}
+                  aria-pressed={isSelected}
+                >
+                  <span className="multi-option-label">{option}</span>
+                </button>
+              )}
             </div>
           );
         })}
@@ -335,11 +326,13 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
   );
 }
 
-/** Small titled divider used to group sub-sections across pages. */
-export function SectionHead({ title, aside }: { title: string; aside?: ReactNode }) {
+/** Small titled divider used to group sub-sections across pages. When `ruled`,
+ * a hairline fills the space after the title. */
+export function SectionHead({ title, aside, ruled = false }: { title: string; aside?: ReactNode; ruled?: boolean }) {
   return (
-    <div className="section-head">
+    <div className={ruled ? "section-head section-head--ruled" : "section-head"}>
       <span className="section-title">{title}</span>
+      {ruled ? <span className="section-head-rule" aria-hidden="true" /> : null}
       {aside != null ? <span className="section-aside">{aside}</span> : null}
     </div>
   );

--- a/frontend/src/hooks/use-pain.ts
+++ b/frontend/src/hooks/use-pain.ts
@@ -18,6 +18,7 @@ const EMPTY_PAIN_OPTIONS = {
   medicines: [] as string[],
   habits: [] as string[],
   other: [] as string[],
+  preselectedMedicines: [] as string[],
 };
 
 export function usePain(enabled: boolean) {
@@ -48,12 +49,12 @@ export function usePain(enabled: boolean) {
       area: "",
       symptoms: "",
       activities: "",
-      medicines: listToCsv(painFieldOptions.medicines),
+      medicines: listToCsv(painFieldOptions.preselectedMedicines),
       habits: "",
       other: "",
       note: "",
     }),
-    [painFieldOptions.medicines],
+    [painFieldOptions.preselectedMedicines],
   );
 
   const painForm = useForm<PainFormValues>({

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3037,6 +3037,15 @@ section.panel > .entry-row + .entry-row { margin-top: var(--layout-tight); }
 .panel-title + .section-head,
 .panel-title + .dashboard-filters + .section-head { margin-top: var(--layout-inline); }
 
+/* Ruled section head: a hairline (--border token, role: Dividers) fills the
+   space after the title, grouping a sub-section without a full-width line. */
+.section-head--ruled { align-items: center; }
+.section-head-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
 /* ──────────────────────────────────────────────────────────────────────
    MCP Access — design-system-aligned styles for McpAccessSection.
    These are permanent (the MCP feature ships in all Settings layouts).

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1299,7 +1299,6 @@ tbody tr:hover {
 }
 .multi-option-chip.active {
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   box-shadow: none;
 }

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -44,18 +44,18 @@ test("changes password and restores the original password", async ({ page }) => 
 });
 
 test("saves birthday in settings", async ({ page }) => {
-  await page.getByRole("button", { name: "Birthday" }).click();
-  await page.getByLabel("Birthday").fill("1995-06-12");
+  await page.getByRole("button", { name: "Preferences" }).click();
 
-  // Wait for the PUT request to complete
+  // Birthday autosaves on change: register the response listener before the
+  // fill that triggers the PUT, otherwise the response can land first.
   const responsePromise = page.waitForResponse(response =>
     response.url().includes('/api/v1/preferences') && response.request().method() === 'PUT'
   );
-  await page.getByRole("button", { name: "Save birthday" }).click();
+  await page.getByLabel("Birthday").fill("1995-06-12");
   await responsePromise;
 
   await page.reload();
   await page.getByRole("button", { name: "settings" }).click();
-  await page.getByRole("button", { name: "Birthday" }).click();
+  await page.getByRole("button", { name: "Preferences" }).click();
   await expect(page.getByLabel("Birthday")).toHaveValue("1995-06-12");
 });


### PR DESCRIPTION
## Summary
- Medicines were all preselected by default in a new pain entry, with no way to opt out. This adds a per-medicine `preselected` flag (default on, so existing behavior is preserved) and a pill selector in settings to choose which medicines start selected.
- Renames the settings **Birthday** tab to **Preferences** (birthday + medicine preselection), makes birthday **autosave** on change, and adds a ruled `SectionHead` style.
- JSON backup now **round-trips** the pain options list and preselection (legacy backups without the field default medicines to preselected).
- Fixes a pre-existing invalid-HTML bug: `MultiSelectField` nested a `<button>` inside a `<button>` in edit mode (React hydration warning).

## Why
Closes #127. The all-or-nothing default forced users to manually deselect medicines on every entry. Per-medicine preselection matches real usage (different meds for different needs). The UI tweaks came from review of the live feature.

## What changed
**Backend**
- `pain_options.preselected` column: `schema.ts` CREATE TABLE, `db.ts` `columnExists` ALTER guard (+ allowlist), `drizzle-schema.ts`. Default `1` preserves current behavior.
- `POST /api/v1/pain/options/preselect` (per-value toggle, mirrors `/remove` `/restore`); `GET /pain/options` now returns `preselectedMedicines`.
- `backup.ts`: export includes `preselectedMedicines`; JSON import restores the options list + preselection (guarded so legacy backups don't wipe options).

**Frontend**
- New pain entry defaults to preselected medicines only (`use-pain.ts`).
- `MedicinePreselectionSection` reuses the Pain/Diary pill selector (`MultiSelectField`); shared React Query cache keeps the Pain form in sync.
- Birthday autosaves (no save button), label → ruled `SectionHead`; `MultiSelectField` edit-mode chip is now a `<div>` so the remove button is no longer nested in a button.

## Reviewer notes
- Backward compatible: `preselected` defaults to `1`; legacy backups handled.
- All queries user-scoped (no IDOR), SQL parametrized.
- Verified end-to-end in browser (toggle in settings -> reflected in new pain entry).
- XLSX backup intentionally does not carry options (it never has — it's an entries spreadsheet).

## Test plan
- [x] Backend: `npm test` (205 pass) + `npm run typecheck` (clean)
- [x] Frontend: `npm run build`, `npm run lint`, `npm test` (50 pass)
- [x] Manual: settings Preferences tab, pill toggle persists, pain form preselection, birthday autosave, edit-mode HTML valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)