### PR TITLE
fix: codebase analysis findings 2026-06-06

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -25,6 +25,7 @@
     "fast-uri": ">=3.1.2",
     "qs": ">=6.15.2",
     "tmp": "^0.2.6",
+    "uuid": ">=11.1.1",
   },
   "packages": {
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
@@ -431,7 +432,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
   "overrides": {
     "fast-uri": ">=3.1.2",
     "tmp": "^0.2.6",
-    "qs": ">=6.15.2"
+    "qs": ">=6.15.2",
+    "uuid": ">=11.1.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
 import { env, allowedOrigins } from "./env.ts";
 import { openDb, runMigrations } from "./db.ts";
 import { createDrizzle, type DrizzleDB } from "./db/index.ts";
@@ -40,6 +41,13 @@ type AppEnv = {
 };
 
 const app = new Hono<AppEnv>();
+
+// Global middleware: security headers
+app.use("*", async (c, next) => {
+  await next();
+  c.res.headers.set("X-Content-Type-Options", "nosniff");
+  c.res.headers.set("X-Frame-Options", "DENY");
+});
 
 // Global middleware: CORS
 app.use(
@@ -168,9 +176,8 @@ app.get("*", (c) => {
 // Global error handler
 app.onError((err, c) => {
   console.error(err);
-  if (err instanceof Response) {
-    return err;
-  }
+  if (err instanceof HTTPException) return err.getResponse();
+  if (err instanceof Response) return err;
   return c.json(
     { error: { code: "INTERNAL_ERROR", message: err?.message ?? "Internal server error" } },
     500

--- a/backend/src/helpers.test.ts
+++ b/backend/src/helpers.test.ts
@@ -33,12 +33,12 @@ describe("readCookie", () => {
 });
 
 describe("buildSessionCookie", () => {
-  test("includes name, sid value, HttpOnly, Path=/, SameSite=Lax, Max-Age", () => {
+  test("includes name, sid value, HttpOnly, Path=/, SameSite=Strict, Max-Age", () => {
     const out = buildSessionCookie("abc123");
     expect(out).toContain(`${env.SESSION_COOKIE_NAME}=abc123`);
     expect(out).toContain("HttpOnly");
     expect(out).toContain("Path=/");
-    expect(out.toLowerCase()).toContain("samesite=lax");
+    expect(out.toLowerCase()).toContain("samesite=strict");
     expect(out).toContain("Max-Age=");
   });
 });

--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -43,7 +43,7 @@ export function readCookie(req: Request, name: string): string | null {
 export function buildSessionCookie(sid: string): string {
   return cookie.serialize(env.SESSION_COOKIE_NAME, sid, {
     httpOnly: true,
-    sameSite: "lax",
+    sameSite: "strict",
     path: "/",
     maxAge: env.SESSION_TTL_SECONDS,
     secure: env.COOKIE_SECURE
@@ -53,7 +53,7 @@ export function buildSessionCookie(sid: string): string {
 export function clearSessionCookie(): string {
   return cookie.serialize(env.SESSION_COOKIE_NAME, "", {
     httpOnly: true,
-    sameSite: "lax",
+    sameSite: "strict",
     path: "/",
     maxAge: 0,
     secure: env.COOKIE_SECURE
@@ -137,7 +137,7 @@ export function rowsToHealthBackup(diaryRows: any[], painRows: any[]): { diary: 
   const diary = {
     source: "health-backend",
     imported_at: new Date().toISOString(),
-    headers: ["date", "hour", "mood level", "depression", "anxiety", "positive moods", "negative moods", "general moods", "description", "gratitude"],
+    headers: ["date", "hour", "mood level", "depression", "anxiety", "positive moods", "negative moods", "general moods", "description", "gratitude", "reflection"],
     rows: diaryRows.map((row) => ({
       date: row.entry_date,
       hour: row.entry_time,
@@ -148,7 +148,8 @@ export function rowsToHealthBackup(diaryRows: any[], painRows: any[]): { diary: 
       "negative moods": row.negative_moods ?? "",
       "general moods": row.general_moods ?? "",
       description: row.description ?? "",
-      gratitude: row.gratitude ?? ""
+      gratitude: row.gratitude ?? "",
+      reflection: row.reflection ?? ""
     }))
   };
 

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -13,7 +13,7 @@ import {
   rowPainField,
   mergeOptions,
 } from "../helpers.ts";
-import { backupImportSchema, prefsSchema, DEFAULT_MODEL } from "../schemas.ts";
+import { backupImportSchema, DEFAULT_MODEL } from "../schemas.ts";
 import { requireAuth } from "../middleware/auth.ts";
 import { loadPainOptionsForUser, loadPreselectedMedicines } from "./pain.ts";
 import { loadMoodOptionsForUser } from "./mood.ts";
@@ -85,7 +85,7 @@ backup.get("/json", (c) => {
     entry_date: r.entryDate, entry_time: r.entryTime,
     mood_level: r.moodLevel, depression_level: r.depressionLevel, anxiety_level: r.anxietyLevel,
     positive_moods: r.positiveMoods, negative_moods: r.negativeMoods, general_moods: r.generalMoods,
-    description: r.description, gratitude: r.gratitude,
+    description: r.description, gratitude: r.gratitude, reflection: r.reflection,
   }));
   const painForBackup = painRows.map((r) => ({
     entry_date: r.entryDate, entry_time: r.entryTime,
@@ -137,8 +137,7 @@ backup.post("/json/import", async (c) => {
   const userId = c.get("userId");
   const body = await parseJson(c, backupImportSchema);
 
-  // Parse prefs before entering the transaction so a ZodError returns 400 not 500.
-  const parsedPrefs = body.prefs ? prefsSchema.parse(body.prefs) : null;
+  const parsedPrefs = body.prefs ?? null;
 
   const tx = rawDb.transaction(() => {
     rawDb.query(`DELETE FROM pain_entries WHERE user_id = ?`).run(userId);
@@ -271,7 +270,7 @@ backup.get("/xlsx", async (c) => {
     entry_date: r.entryDate, entry_time: r.entryTime,
     mood_level: r.moodLevel, depression_level: r.depressionLevel, anxiety_level: r.anxietyLevel,
     positive_moods: r.positiveMoods, negative_moods: r.negativeMoods, general_moods: r.generalMoods,
-    description: r.description, gratitude: r.gratitude,
+    description: r.description, gratitude: r.gratitude, reflection: r.reflection,
   }));
   const painForBackup = painRows.map((r) => ({
     entry_date: r.entryDate, entry_time: r.entryTime,

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -25,12 +25,12 @@ export const diarySchema = z.object({
   moodLevel: z.number().min(1).max(9).nullable().optional(),
   depressionLevel: z.number().min(1).max(9).nullable().optional(),
   anxietyLevel: z.number().min(1).max(9).nullable().optional(),
-  positiveMoods: z.string().optional().default(""),
-  negativeMoods: z.string().optional().default(""),
-  generalMoods: z.string().optional().default(""),
-  description: z.string().optional().default(""),
-  gratitude: z.string().optional().default(""),
-  reflection: z.string().optional()
+  positiveMoods: z.string().max(2000).optional().default(""),
+  negativeMoods: z.string().max(2000).optional().default(""),
+  generalMoods: z.string().max(2000).optional().default(""),
+  description: z.string().max(10000).optional().default(""),
+  gratitude: z.string().max(10000).optional().default(""),
+  reflection: z.string().max(10000).optional()
 });
 
 export const painValueSchema = z.union([z.string(), z.array(z.string())]).optional();
@@ -47,7 +47,7 @@ export const painSchema = z.object({
   medicines: painValueSchema,
   habits: painValueSchema,
   other: painValueSchema,
-  note: z.string().optional().default(""),
+  note: z.string().max(2000).optional().default(""),
   tags: z
     .object({
       area: z.array(z.string()).optional(),
@@ -64,28 +64,28 @@ export const painSchema = z.object({
 export const cbtSchema = z.object({
   entryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   entryTime: z.string().regex(/^\d{2}:\d{2}$/),
-  situation: z.string().optional().default(""),
-  thoughts: z.string().optional().default(""),
-  helpfulReasoning: z.string().optional().default(""),
-  mainUnhelpfulThought: z.string().optional().default(""),
-  effectOfBelieving: z.string().optional().default(""),
-  evidenceForAgainst: z.string().optional().default(""),
-  alternativeExplanation: z.string().optional().default(""),
-  worstBestScenario: z.string().optional().default(""),
-  friendAdvice: z.string().optional().default(""),
-  productiveResponse: z.string().optional().default(""),
+  situation: z.string().max(5000).optional().default(""),
+  thoughts: z.string().max(5000).optional().default(""),
+  helpfulReasoning: z.string().max(5000).optional().default(""),
+  mainUnhelpfulThought: z.string().max(5000).optional().default(""),
+  effectOfBelieving: z.string().max(5000).optional().default(""),
+  evidenceForAgainst: z.string().max(5000).optional().default(""),
+  alternativeExplanation: z.string().max(5000).optional().default(""),
+  worstBestScenario: z.string().max(5000).optional().default(""),
+  friendAdvice: z.string().max(5000).optional().default(""),
+  productiveResponse: z.string().max(5000).optional().default(""),
 });
 
 export const dbtSchema = z.object({
   entryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   entryTime: z.string().regex(/^\d{2}:\d{2}$/),
-  emotionName: z.string().optional().default(""),
-  allowAffirmation: z.string().optional().default(""),
-  watchEmotion: z.string().optional().default(""),
-  bodyLocation: z.string().optional().default(""),
-  bodyFeeling: z.string().optional().default(""),
-  presentMoment: z.string().optional().default(""),
-  emotionReturns: z.string().optional().default(""),
+  emotionName: z.string().max(200).optional().default(""),
+  allowAffirmation: z.string().max(5000).optional().default(""),
+  watchEmotion: z.string().max(5000).optional().default(""),
+  bodyLocation: z.string().max(500).optional().default(""),
+  bodyFeeling: z.string().max(5000).optional().default(""),
+  presentMoment: z.string().max(5000).optional().default(""),
+  emotionReturns: z.string().max(5000).optional().default(""),
 });
 
 export const prefsSchema = z.object({
@@ -126,13 +126,15 @@ export const mcpTokenCreateSchema = z.object({
   ),
 });
 
+const BACKUP_MAX_ROWS = 50_000;
+
 export const backupImportSchema = z.object({
   diary: z
-    .object({ rows: z.array(z.record(z.string(), z.any())).max(50_000).default([]) })
+    .object({ rows: z.array(z.record(z.string(), z.any())).max(BACKUP_MAX_ROWS).default([]) })
     .optional(),
   pain: z
     .object({
-      rows: z.array(z.record(z.string(), z.any())).max(50_000).default([]),
+      rows: z.array(z.record(z.string(), z.any())).max(BACKUP_MAX_ROWS).default([]),
       options: z
         .object({
           options: z.record(z.string(), z.array(z.string())).optional(),
@@ -142,7 +144,7 @@ export const backupImportSchema = z.object({
         .optional()
     })
     .optional(),
-  prefs: z.record(z.string(), z.any()).optional()
+  prefs: prefsSchema.optional()
 });
 
 export const optionFieldSchema = z.object({

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -15,7 +15,7 @@
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.17.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.11",
       },
@@ -662,9 +662,9 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
+    "react-router": ["react-router@7.17.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ=="],
 
-    "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
+    "react-router-dom": ["react-router-dom@7.17.0", "", { "dependencies": { "react-router": "7.17.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
-    "react-router-dom": "^7.13.1",
+    "react-router-dom": "^7.17.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/frontend/src/hooks/use-cbt.ts
+++ b/frontend/src/hooks/use-cbt.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -28,6 +28,8 @@ export function useCbt(enabled: boolean) {
   const queryClient = useQueryClient();
   const [editingCbt, setEditingCbt] = useState<CbtEntry | null>(null);
   const [confirmDeleteCbt, setConfirmDeleteCbt] = useState<number | null>(null);
+  const cbtResetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(cbtResetTimerRef.current), []);
 
   const cbtQuery = useQuery({
     queryKey: ["cbt"],
@@ -70,7 +72,8 @@ export function useCbt(enabled: boolean) {
       setEditingCbt(null);
       cbtForm.reset(freshDefaults());
       await queryClient.invalidateQueries({ queryKey: ["cbt"] });
-      setTimeout(() => cbtMutation.reset(), 3000);
+      clearTimeout(cbtResetTimerRef.current);
+      cbtResetTimerRef.current = setTimeout(() => cbtMutation.reset(), 3000);
     },
   });
 

--- a/frontend/src/hooks/use-dbt.ts
+++ b/frontend/src/hooks/use-dbt.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -25,6 +25,8 @@ export function useDbt(enabled: boolean) {
   const queryClient = useQueryClient();
   const [editingDbt, setEditingDbt] = useState<DbtEntry | null>(null);
   const [confirmDeleteDbt, setConfirmDeleteDbt] = useState<number | null>(null);
+  const dbtResetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(dbtResetTimerRef.current), []);
 
   const dbtQuery = useQuery({
     queryKey: ["dbt"],
@@ -64,7 +66,8 @@ export function useDbt(enabled: boolean) {
       setEditingDbt(null);
       dbtForm.reset(freshDefaults());
       await queryClient.invalidateQueries({ queryKey: ["dbt"] });
-      setTimeout(() => dbtMutation.reset(), 3000);
+      clearTimeout(dbtResetTimerRef.current);
+      dbtResetTimerRef.current = setTimeout(() => dbtMutation.reset(), 3000);
     },
   });
 

--- a/frontend/src/hooks/use-diary.ts
+++ b/frontend/src/hooks/use-diary.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -20,6 +20,8 @@ export function useDiary(enabled: boolean) {
   const queryClient = useQueryClient();
   const [editingDiary, setEditingDiary] = useState<DiaryEntry | null>(null);
   const [confirmDeleteDiary, setConfirmDeleteDiary] = useState<number | null>(null);
+  const diaryResetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(diaryResetTimerRef.current), []);
 
   const diaryQuery = useQuery({
     queryKey: ["diary"],
@@ -91,7 +93,8 @@ export function useDiary(enabled: boolean) {
         gratitude: "",
       });
       await queryClient.invalidateQueries({ queryKey: ["diary"] });
-      setTimeout(() => diaryMutation.reset(), 3000);
+      clearTimeout(diaryResetTimerRef.current);
+      diaryResetTimerRef.current = setTimeout(() => diaryMutation.reset(), 3000);
     },
   });
 

--- a/frontend/src/hooks/use-pain.ts
+++ b/frontend/src/hooks/use-pain.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -25,6 +25,8 @@ export function usePain(enabled: boolean) {
   const queryClient = useQueryClient();
   const [editingPain, setEditingPain] = useState<PainEntry | null>(null);
   const [confirmDeletePain, setConfirmDeletePain] = useState<number | null>(null);
+  const painResetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(painResetTimerRef.current), []);
 
   const painQuery = useQuery({
     queryKey: ["pain"],
@@ -103,7 +105,8 @@ export function usePain(enabled: boolean) {
       setEditingPain(null);
       painForm.reset(createDefaultPainFormValues());
       await queryClient.invalidateQueries({ queryKey: ["pain"] });
-      setTimeout(() => painMutation.reset(), 3000);
+      clearTimeout(painResetTimerRef.current);
+      painResetTimerRef.current = setTimeout(() => painMutation.reset(), 3000);
     },
   });
 


### PR DESCRIPTION
## Summary

- **Critical bug:** `onError` non gestiva `HTTPException` — tutti i 400 di validazione diventavano 500
- **Bug:** campo `reflection` mancante da export JSON e XLSX del backup (archiviato, importato, ma silenziosamente perso all'export)
- **Bug:** `backupImportSchema.prefs` ora usa `prefsSchema` direttamente — `ZodError` nella validazione prefs ritorna 400 non 500
- **Security:** headers `X-Content-Type-Options: nosniff` e `X-Frame-Options: DENY` su tutte le risposte
- **Security:** session cookie aggiornato a `SameSite=Strict` (era `Lax`; costo UX: zero)
- **Security:** aggiunto `.max()` a tutti i campi free-text in `diarySchema`, `painSchema`, `cbtSchema`, `dbtSchema` (prevenzione payload multi-MB)
- **Quality:** costante `BACKUP_MAX_ROWS` estratta (era `50_000` inline duplicata)
- **Quality:** fix `setTimeout` senza cleanup in `useDiary`, `usePain`, `useCbt`, `useDbt` — timer ID salvato in `useRef`, `clearTimeout` al dismount
- **Deps:** `react-router-dom` 7.13.1 → 7.17.0 (fix GHSA-8x6r-g9mw-2r78, DoS via path expansion)
- **Deps:** override `uuid >=11.1.1` in backend (GHSA-w5hq-g745-h8pq via exceljs)
- **Test:** aggiornato `helpers.test.ts` per `SameSite=Strict`

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/health/issues/136

## Sub-analyst reports

- **Security:** `HTTPException` error handler bug (critical), PAT SHA-256 no-KDF (deferred, già #120), unbounded free-text fields (shipped), missing security headers (shipped), SameSite=Strict (shipped)
- **Quality:** `reflection` missing from backup exports (shipped), `type Env` duplication ×9 routes (deferred #136), screens.tsx 1971 lines (deferred #136), non-functional "Show more" buttons (deferred #136)
- **Bugs:** `HTTPException` → 500 (shipped, critical), prepared statements leak (deferred, già #120), `ZodError` → 500 in prefs import (shipped), `setTimeout` no cleanup (shipped)
- **Tests:** `POST /backup/purge` untested (già #120), MCP layer zero coverage (già #120), DELETE IDOR gaps in CBT/DBT/memorable-days (deferred #136), bcrypt upgrade path untested (deferred #136)
- **Deps:** react-router-dom GHSA-8x6r-g9mw-2r78 (shipped), uuid CVE (shipped), @hono/node-server GHSA-92pp-h63x-v22m (deferred #136), esbuild dev-only CVE (già #120)
- **Performance:** unbounded SELECTs diary/pain/CBT/DBT (già #120), emoji catalog eager load (deferred #136), redundant `csvToList` calls (deferred #136)

---
Generated automatically by Codebase Analyst — 2026-06-06