### PR TITLE
feat(db): metric_types table + per-user seed (#138)

### DIFF
--- a/backend/src/db/drizzle-schema.ts
+++ b/backend/src/db/drizzle-schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index, primaryKey } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index, uniqueIndex, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -173,6 +173,28 @@ export const moodOptions = sqliteTable("mood_options", {
   field: text("field").notNull(),
   value: text("value").notNull(),
 });
+
+export const metricTypes = sqliteTable(
+  "metric_types",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+    key: text("key").notNull(),
+    label: text("label").notNull(),
+    kind: text("kind").notNull(),
+    unit: text("unit"),
+    minValue: real("min_value"),
+    maxValue: real("max_value"),
+    step: real("step"),
+    configJson: text("config_json").notNull().default("{}"),
+    archivedAt: text("archived_at"),
+    createdAt: text("created_at").notNull().default("CURRENT_TIMESTAMP"),
+    updatedAt: text("updated_at").notNull().default("CURRENT_TIMESTAMP"),
+  },
+  (table) => [
+    uniqueIndex("idx_metric_types_user_key").on(table.userId, table.key),
+  ]
+);
 
 export const mcpTokens = sqliteTable(
   "mcp_tokens",

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -22,5 +22,6 @@ export {
   painOptions,
   moodOptions,
   mcpTokens,
-  memorableDays
+  memorableDays,
+  metricTypes
 } from "./drizzle-schema.ts";

--- a/backend/src/metric-types.test.ts
+++ b/backend/src/metric-types.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { runMigrations } from "./db.ts";
+import { BUILTIN_METRIC_TYPES } from "./schema.ts";
+
+type MetricRow = {
+  key: string;
+  kind: string;
+  unit: string | null;
+  min_value: number | null;
+  max_value: number | null;
+};
+type CountRow = { c: number };
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  db.query("PRAGMA foreign_keys = ON").run();
+  runMigrations(db); // creates tables; 0 users => nothing seeded yet
+  return db;
+}
+
+function addUser(db: Database, email: string): void {
+  db.query("INSERT INTO users (email, password_hash) VALUES (?, 'x')").run(email);
+}
+
+function metricRows(db: Database, userId: number): MetricRow[] {
+  return db
+    .query("SELECT key, kind, unit, min_value, max_value FROM metric_types WHERE user_id = ? ORDER BY id")
+    .all(userId) as MetricRow[];
+}
+
+describe("metric_types seed", () => {
+  test("seeds every built-in type for a user, with correct kind/range", () => {
+    const db = freshDb();
+    addUser(db, "a@example.com");
+    runMigrations(db); // idempotent re-run seeds the now-existing user
+
+    const rows = metricRows(db, 1);
+    expect(rows.length).toBe(BUILTIN_METRIC_TYPES.length);
+
+    const byKey = new Map(rows.map((r) => [r.key, r]));
+    expect(byKey.get("mood")).toMatchObject({ kind: "scale", min_value: 1, max_value: 9 });
+    expect(byKey.get("coffee")).toMatchObject({ kind: "counter", min_value: 0 });
+    expect(byKey.get("positive_moods")?.kind).toBe("tags");
+    expect(byKey.get("description")?.kind).toBe("text");
+    expect(byKey.get("measurement")?.kind).toBe("measure");
+    expect(byKey.get("cbt_situation")?.kind).toBe("text");
+  });
+
+  test("is idempotent — re-running migrations adds no duplicates", () => {
+    const db = freshDb();
+    addUser(db, "a@example.com");
+    runMigrations(db);
+    runMigrations(db);
+    runMigrations(db);
+
+    const count = db.query("SELECT count(*) AS c FROM metric_types WHERE user_id = 1").get() as CountRow;
+    expect(count.c).toBe(BUILTIN_METRIC_TYPES.length);
+  });
+
+  test("seeds each user independently", () => {
+    const db = freshDb();
+    addUser(db, "a@example.com");
+    addUser(db, "b@example.com");
+    runMigrations(db);
+
+    expect(metricRows(db, 1).length).toBe(BUILTIN_METRIC_TYPES.length);
+    expect(metricRows(db, 2).length).toBe(BUILTIN_METRIC_TYPES.length);
+  });
+
+  test("built-in keys are unique", () => {
+    const keys = BUILTIN_METRIC_TYPES.map((m) => m.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/backend/src/metric-types.test.ts
+++ b/backend/src/metric-types.test.ts
@@ -9,6 +9,8 @@ type MetricRow = {
   unit: string | null;
   min_value: number | null;
   max_value: number | null;
+  config_json: string;
+  archived_at: string | null;
 };
 type CountRow = { c: number };
 
@@ -19,27 +21,36 @@ function freshDb(): Database {
   return db;
 }
 
-function addUser(db: Database, email: string): void {
-  db.query("INSERT INTO users (email, password_hash) VALUES (?, 'x')").run(email);
+function addUser(db: Database, email: string): number {
+  const res = db.query("INSERT INTO users (email, password_hash) VALUES (?, 'x')").run(email);
+  return Number(res.lastInsertRowid);
 }
 
 function metricRows(db: Database, userId: number): MetricRow[] {
   return db
-    .query("SELECT key, kind, unit, min_value, max_value FROM metric_types WHERE user_id = ? ORDER BY id")
+    .query(
+      "SELECT key, kind, unit, min_value, max_value, config_json, archived_at FROM metric_types WHERE user_id = ? ORDER BY id"
+    )
     .all(userId) as MetricRow[];
 }
 
 describe("metric_types seed", () => {
-  test("seeds every built-in type for a user, with correct kind/range", () => {
+  test("seeds every built-in type for a user, with correct kind/range/defaults", () => {
     const db = freshDb();
-    addUser(db, "a@example.com");
+    const userId = addUser(db, "a@example.com");
     runMigrations(db); // idempotent re-run seeds the now-existing user
 
-    const rows = metricRows(db, 1);
+    const rows = metricRows(db, userId);
     expect(rows.length).toBe(BUILTIN_METRIC_TYPES.length);
 
     const byKey = new Map(rows.map((r) => [r.key, r]));
-    expect(byKey.get("mood")).toMatchObject({ kind: "scale", min_value: 1, max_value: 9 });
+    expect(byKey.get("mood")).toMatchObject({
+      kind: "scale",
+      min_value: 1,
+      max_value: 9,
+      config_json: "{}",
+      archived_at: null,
+    });
     expect(byKey.get("coffee")).toMatchObject({ kind: "counter", min_value: 0 });
     expect(byKey.get("positive_moods")?.kind).toBe("tags");
     expect(byKey.get("description")?.kind).toBe("text");
@@ -49,23 +60,35 @@ describe("metric_types seed", () => {
 
   test("is idempotent — re-running migrations adds no duplicates", () => {
     const db = freshDb();
-    addUser(db, "a@example.com");
+    const userId = addUser(db, "a@example.com");
     runMigrations(db);
     runMigrations(db);
     runMigrations(db);
 
-    const count = db.query("SELECT count(*) AS c FROM metric_types WHERE user_id = 1").get() as CountRow;
+    const count = db
+      .query("SELECT count(*) AS c FROM metric_types WHERE user_id = ?")
+      .get(userId) as CountRow;
     expect(count.c).toBe(BUILTIN_METRIC_TYPES.length);
   });
 
   test("seeds each user independently", () => {
     const db = freshDb();
-    addUser(db, "a@example.com");
-    addUser(db, "b@example.com");
+    const a = addUser(db, "a@example.com");
+    const b = addUser(db, "b@example.com");
     runMigrations(db);
 
-    expect(metricRows(db, 1).length).toBe(BUILTIN_METRIC_TYPES.length);
-    expect(metricRows(db, 2).length).toBe(BUILTIN_METRIC_TYPES.length);
+    expect(metricRows(db, a).length).toBe(BUILTIN_METRIC_TYPES.length);
+    expect(metricRows(db, b).length).toBe(BUILTIN_METRIC_TYPES.length);
+  });
+
+  test("rejects an invalid kind via the DB CHECK constraint", () => {
+    const db = freshDb();
+    const userId = addUser(db, "a@example.com");
+    expect(() =>
+      db
+        .query("INSERT INTO metric_types (user_id, key, label, kind) VALUES (?, 'bad', 'Bad', 'nonsense')")
+        .run(userId)
+    ).toThrow();
   });
 
   test("built-in keys are unique", () => {

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -69,7 +69,9 @@ function metricTypeSeedRow(m: BuiltinMetricType): string {
 }
 
 // INSERT OR IGNORE + the UNIQUE(user_id, key) index make this idempotent,
-// matching the mood_options/pain_options seeding pattern.
+// matching the mood_options/pain_options seeding pattern. The SQL is
+// string-built from BUILTIN_METRIC_TYPES (static developer data, never
+// user input) with single quotes escaped, so it is not an injection surface.
 function buildMetricTypesSeedSql(): string {
   const values = BUILTIN_METRIC_TYPES.map(metricTypeSeedRow).join("\n     UNION ALL\n     ");
   return `INSERT OR IGNORE INTO metric_types (user_id, key, label, kind, unit, min_value, max_value, step)
@@ -436,7 +438,7 @@ export const migrationStatements: string[] = [
     user_id INTEGER NOT NULL,
     key TEXT NOT NULL,
     label TEXT NOT NULL,
-    kind TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN (${METRIC_KINDS.map((k) => `'${k}'`).join(", ")})),
     unit TEXT,
     min_value REAL,
     max_value REAL,

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -1,4 +1,84 @@
-export const SCHEMA_VERSION = 10;
+export const SCHEMA_VERSION = 11;
+
+export const METRIC_KINDS = ["scale", "counter", "tags", "text", "measure"] as const;
+export type MetricKind = (typeof METRIC_KINDS)[number];
+
+export type BuiltinMetricType = {
+  key: string;
+  label: string;
+  kind: MetricKind;
+  unit: string | null;
+  min: number | null;
+  max: number | null;
+  step: number | null;
+};
+
+// Built-in metric types seeded per user. Single source of truth for both
+// the seed SQL (built below) and the seed test, so they can never drift.
+export const BUILTIN_METRIC_TYPES: readonly BuiltinMetricType[] = [
+  // scales (1-9)
+  { key: "mood", label: "Mood", kind: "scale", unit: null, min: 1, max: 9, step: 1 },
+  { key: "depression", label: "Depression", kind: "scale", unit: null, min: 1, max: 9, step: 1 },
+  { key: "anxiety", label: "Anxiety", kind: "scale", unit: null, min: 1, max: 9, step: 1 },
+  { key: "pain", label: "Pain", kind: "scale", unit: null, min: 1, max: 9, step: 1 },
+  { key: "fatigue", label: "Fatigue", kind: "scale", unit: null, min: 1, max: 9, step: 1 },
+  // counter
+  { key: "coffee", label: "Coffee", kind: "counter", unit: null, min: 0, max: null, step: 1 },
+  // tags
+  { key: "positive_moods", label: "Positive moods", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "negative_moods", label: "Negative moods", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "general_moods", label: "General moods", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "area", label: "Area", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "symptoms", label: "Symptoms", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "activities", label: "Activities", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "medicines", label: "Medicines", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "habits", label: "Habits", kind: "tags", unit: null, min: null, max: null, step: null },
+  { key: "other", label: "Other", kind: "tags", unit: null, min: null, max: null, step: null },
+  // free-text fields (diary / pain)
+  { key: "description", label: "Description", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "gratitude", label: "Gratitude", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "note", label: "Note", kind: "text", unit: null, min: null, max: null, step: null },
+  // CBT therapy fields (text)
+  { key: "cbt_situation", label: "Situation", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_thoughts", label: "Thoughts", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_helpful_reasoning", label: "Helpful reasoning", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_main_unhelpful_thought", label: "Main unhelpful thought", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_effect_of_believing", label: "Effect of believing", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_evidence_for_against", label: "Evidence for & against", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_alternative_explanation", label: "Alternative explanation", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_worst_best_scenario", label: "Worst & best scenario", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_friend_advice", label: "Friend's advice", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "cbt_productive_response", label: "Productive response", kind: "text", unit: null, min: null, max: null, step: null },
+  // DBT therapy fields (text)
+  { key: "dbt_emotion_name", label: "Emotion name", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_allow_affirmation", label: "Allow affirmation", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_watch_emotion", label: "Watch the emotion", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_body_location", label: "Body location", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_body_feeling", label: "Body feeling", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_present_moment", label: "Present moment", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "dbt_emotion_returns", label: "Emotion returns", kind: "text", unit: null, min: null, max: null, step: null },
+  // generic starters for custom pages
+  { key: "free_text", label: "Free text", kind: "text", unit: null, min: null, max: null, step: null },
+  { key: "measurement", label: "Measurement", kind: "measure", unit: null, min: null, max: null, step: null },
+];
+
+function metricTypeSeedRow(m: BuiltinMetricType): string {
+  const str = (v: string | null) => (v === null ? "NULL" : `'${v.replace(/'/g, "''")}'`);
+  const num = (v: number | null) => (v === null ? "NULL" : String(v));
+  return `SELECT ${str(m.key)} AS key, ${str(m.label)} AS label, ${str(m.kind)} AS kind, ${str(m.unit)} AS unit, ${num(m.min)} AS min_value, ${num(m.max)} AS max_value, ${num(m.step)} AS step`;
+}
+
+// INSERT OR IGNORE + the UNIQUE(user_id, key) index make this idempotent,
+// matching the mood_options/pain_options seeding pattern.
+function buildMetricTypesSeedSql(): string {
+  const values = BUILTIN_METRIC_TYPES.map(metricTypeSeedRow).join("\n     UNION ALL\n     ");
+  return `INSERT OR IGNORE INTO metric_types (user_id, key, label, kind, unit, min_value, max_value, step)
+   SELECT u.id, v.key, v.label, v.kind, v.unit, v.min_value, v.max_value, v.step
+   FROM users u
+   CROSS JOIN (
+     ${values}
+   ) AS v`;
+}
 
 export const migrationStatements: string[] = [
   `CREATE TABLE IF NOT EXISTS users (
@@ -348,7 +428,27 @@ export const migrationStatements: string[] = [
     VALUES ('delete', old.id, COALESCE(old.note, ''), COALESCE(old.symptoms, ''));
     INSERT INTO pain_fts(rowid, note, symptoms)
     VALUES (new.id, COALESCE(new.note, ''), COALESCE(new.symptoms, ''));
-  END`
+  END`,
+
+  // ── metric_types: modular value-type definitions (built-in + custom) ────
+  `CREATE TABLE IF NOT EXISTS metric_types (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    key TEXT NOT NULL,
+    label TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    unit TEXT,
+    min_value REAL,
+    max_value REAL,
+    step REAL,
+    config_json TEXT NOT NULL DEFAULT '{}',
+    archived_at TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_metric_types_user_key ON metric_types(user_id, key)`,
+  buildMetricTypesSeedSql(),
 ];
 
 export const TAG_TYPES = ["area", "symptoms", "activities", "medicines", "habits", "other"] as const;


### PR DESCRIPTION
Phase 1 of the modular refactor (ADR `docs/modular/01-architecture.md`). First, additive data-layer step — no existing tables touched, app stays fully functional.

## What
- New `metric_types` table: modular value-type definitions (`scale`/`counter`/`tags`/`text`/`measure`), with `unit`/`min_value`/`max_value`/`step`, `config_json`, `archived_at`, `UNIQUE(user_id, key)`, and a DB-level `CHECK(kind IN (...))`.
- Seeds the 37 built-in types **per user**, idempotently — mirrors the existing `mood_options`/`pain_options` seeding (`INSERT OR IGNORE` + `UNIQUE`, runs safely on every startup).
- Built-in types defined once as a typed array `BUILTIN_METRIC_TYPES` (single source of truth for the seed SQL and the test).
- Drizzle schema + `db/index.ts` re-export added. `SCHEMA_VERSION` 10 → 11.

## Tests
`backend/src/metric-types.test.ts`: seed completeness + kind/range/defaults, idempotency (3× re-run), per-user isolation, CHECK rejection, key uniqueness. Full backend suite 211 pass; typecheck + frontend build green; migration-fixture check passes.

## Review
Opus reviewer verdict `pass` (0 critical, 0 AGENTS.md violations); all 4 suggestions applied (DB CHECK on kind, test id capture, default-column assertions, static-data comment).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)