### PR TITLE
feat: add error boundaries (root + per-section)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -14,6 +14,7 @@
         "react": "^19.2.0",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.0",
+        "react-error-boundary": "^6.1.2",
         "react-hook-form": "^7.71.2",
         "react-router-dom": "^7.17.0",
         "zod": "^4.3.6",
@@ -657,6 +658,8 @@
     "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-error-boundary": ["react-error-boundary@6.1.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng=="],
 
     "react-hook-form": ["react-hook-form@7.75.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react": "^19.2.0",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.0",
+    "react-error-boundary": "^6.1.2",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.17.0",
     "zod": "^4.3.6",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { LoginScreen } from "./app/LoginScreen";
 import { Sidebar } from "./app/Sidebar";
 import { CbtSection, DbtSection, DashboardSection, DesignSystemSection, DiarySection, PainSection, SettingsSection } from "./app/screens";
 import { MemorableDaysSection } from "./app/memorable-days";
+import { SectionErrorBoundary } from "./app/ErrorBoundary";
 import { formatDocumentTitle, navLabels, type NavItem } from "./app/core";
 
 function App() {
@@ -265,6 +266,7 @@ function App() {
           <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
         </button>
 
+        <SectionErrorBoundary resetKey={nav}>
         {nav === "dashboard" && (
           <DashboardSection
             dashboardFrom={dashboard.dashboardFrom} dashboardTo={dashboard.dashboardTo}
@@ -338,6 +340,7 @@ function App() {
         )}
 
         {nav === "design-system" && <DesignSystemSection />}
+        </SectionErrorBoundary>
       </main>
     </div>
   );

--- a/frontend/src/app/ErrorBoundary.test.tsx
+++ b/frontend/src/app/ErrorBoundary.test.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RootErrorBoundary, SectionErrorBoundary } from "./ErrorBoundary";
+
+function Boom({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("kaboom");
+  }
+  return <p>recovered content</p>;
+}
+
+describe("<RootErrorBoundary />", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders children when they do not throw", () => {
+    render(
+      <RootErrorBoundary>
+        <p>healthy app</p>
+      </RootErrorBoundary>,
+    );
+    expect(screen.getByText("healthy app")).toBeInTheDocument();
+  });
+
+  test("renders fallback with Reload + Try again when a child throws", () => {
+    render(
+      <RootErrorBoundary>
+        <Boom shouldThrow />
+      </RootErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Reload/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument();
+  });
+
+  test("logs the error with context (no silent catch)", () => {
+    const spy = vi.spyOn(console, "error");
+    render(
+      <RootErrorBoundary>
+        <Boom shouldThrow />
+      </RootErrorBoundary>,
+    );
+    const loggedRootError = spy.mock.calls.some(
+      (call) => typeof call[0] === "string" && call[0].includes("[error-boundary:root]"),
+    );
+    expect(loggedRootError).toBe(true);
+  });
+});
+
+describe("<SectionErrorBoundary />", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("isolates a section crash and recovers via Try again", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [crash, setCrash] = useState(true);
+      return (
+        <div>
+          <p>sidebar stays mounted</p>
+          <SectionErrorBoundary resetKey="dashboard">
+            <Boom shouldThrow={crash} />
+          </SectionErrorBoundary>
+          <button type="button" onClick={() => setCrash(false)}>
+            fix it
+          </button>
+        </div>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByText("sidebar stays mounted")).toBeInTheDocument();
+    expect(screen.getByText(/This section ran into a problem/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /fix it/i }));
+    await user.click(screen.getByRole("button", { name: /Try again/i }));
+
+    expect(screen.getByText("recovered content")).toBeInTheDocument();
+    expect(screen.queryByText(/This section ran into a problem/i)).not.toBeInTheDocument();
+  });
+
+  test("auto-resets when resetKey changes (navigating to another section)", () => {
+    const { rerender } = render(
+      <SectionErrorBoundary resetKey="dashboard">
+        <Boom shouldThrow />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText(/This section ran into a problem/i)).toBeInTheDocument();
+
+    rerender(
+      <SectionErrorBoundary resetKey="diary">
+        <Boom shouldThrow={false} />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("recovered content")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/src/app/ErrorBoundary.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+
+function logError(error: unknown, info: { componentStack?: string | null }, context: string) {
+  console.error(`[error-boundary:${context}]`, error, info.componentStack ?? "");
+}
+
+function RootFallback({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <main className="screen auth-screen">
+      <section className="auth-card stack" role="alert">
+        <h1>Something went wrong</h1>
+        <p className="hint">
+          The app hit an unexpected error and couldn&apos;t continue. Reloading
+          usually clears it.
+        </p>
+        <button type="button" className="active" onClick={() => window.location.reload()}>
+          Reload
+        </button>
+        <button type="button" onClick={resetErrorBoundary}>
+          Try again
+        </button>
+      </section>
+    </main>
+  );
+}
+
+function SectionFallback({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="empty-state" role="alert">
+      <p className="empty-state-title">This section ran into a problem</p>
+      <p className="empty-state-copy">
+        Something went wrong while loading this view. The rest of the app is
+        still available.
+      </p>
+      <div>
+        <button type="button" onClick={resetErrorBoundary}>
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function RootErrorBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      FallbackComponent={RootFallback}
+      onError={(error, info) => logError(error, info, "root")}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export function SectionErrorBoundary({
+  children,
+  resetKey,
+}: {
+  children: ReactNode;
+  resetKey?: unknown;
+}) {
+  return (
+    <ErrorBoundary
+      FallbackComponent={SectionFallback}
+      onError={(error, info) => logError(error, info, "section")}
+      resetKeys={[resetKey]}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import { RootErrorBoundary } from "./app/ErrorBoundary";
 import "./styles.css";
 
 document.body.classList.add("mh-app");
@@ -13,7 +14,9 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
+        <RootErrorBoundary>
+          <App />
+        </RootErrorBoundary>
       </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>


### PR DESCRIPTION
## What

Adds React error boundaries via [`react-error-boundary`](https://github.com/bvaughn/react-error-boundary):

- **`RootErrorBoundary`** wraps `<App/>` in `main.tsx` (inside the providers) — full-screen fallback with *Reload* / *Try again*.
- **`SectionErrorBoundary`** wraps the section switch in `App.tsx`, keyed on `nav` — a crash in one section shows an inline fallback while the sidebar stays mounted, and navigating away auto-resets it.

## Why

Currently an uncaught error during render = blank white screen with zero feedback. The app had **no** error boundary, so any render-time crash in a section took down the whole UI silently. This is the recognizable signature of a missing ErrorBoundary.

## Notes

- The app uses conditional rendering on `nav` (not react-router `<Route>`), so one boundary keyed on `nav` replaces what would otherwise be 8 repetitive per-section wrappers (DRY, AGENTS.md §3).
- Fallback UI reuses existing design tokens/classes only (`auth-screen`, `auth-card`, `empty-state`, base `button`) — no raw hex, no ad-hoc px; dark mode (dark/grey/oled) inherited automatically.
- `onError` logs error + componentStack with a static context label, no user data (§10). `logError` types the error as `unknown` (§5).
- Tests: 4 new tests cover happy path, fallback render, context logging, section isolation + recovery, auto-reset on nav change.

Reviewed by an Opus review-gate subagent: verdict **pass**, 0 critical issues, 0 AGENTS.md violations, tests 60/60, build green.

Refs #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)