### PR TITLE
feat: add Sonner toast feedback on entry saves

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
         "react-router-dom": "^7.17.0",
+        "sonner": "^2.0.7",
         "zod": "^4.3.6",
         "zustand": "^5.0.11",
       },
@@ -687,6 +688,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.17.0",
+    "sonner": "^2.0.7",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Toaster } from "sonner";
 import { useAuth, useDiary, usePain, useCbt, useDbt, useDashboard, useMemorableDays, useSettings } from "./hooks";
 import { LoginScreen } from "./app/LoginScreen";
 import { Sidebar } from "./app/Sidebar";
@@ -240,11 +241,21 @@ function App() {
     // we only need to attach the listeners once at mount.
   }, []);
 
+  // The app ships only dark themes (dark, grey, oled — see themeIds in app/core.ts),
+  // so the toaster is pinned to "dark" to match. There is no light mode to follow.
+  const toaster = <Toaster theme="dark" richColors position="bottom-right" />;
+
   if (!auth.user) {
-    return <LoginScreen loginForm={auth.loginForm} loginMutation={auth.loginMutation} />;
+    return (
+      <>
+        <LoginScreen loginForm={auth.loginForm} loginMutation={auth.loginMutation} />
+        {toaster}
+      </>
+    );
   }
 
   return (
+    <>
     <div className={`shell${sidebarCollapsed ? " collapsed" : ""}${mobileSidebarOpen ? " mobile-open" : ""}`}>
       <Sidebar
         nav={nav}
@@ -340,6 +351,8 @@ function App() {
         {nav === "design-system" && <DesignSystemSection />}
       </main>
     </div>
+    {toaster}
+    </>
   );
 }
 

--- a/frontend/src/hooks/use-cbt.ts
+++ b/frontend/src/hooks/use-cbt.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { apiEnvelopeSchema, apiFetch, splitDateTime, toLocalDateTimeValue } from "../lib";
 import { cbtFormSchema, cbtListSchema } from "../app/core";
 import type { CbtEntry, CbtFormValues } from "../app/core";
@@ -72,8 +73,12 @@ export function useCbt(enabled: boolean) {
       setEditingCbt(null);
       cbtForm.reset(freshDefaults());
       await queryClient.invalidateQueries({ queryKey: ["cbt"] });
+      toast.success("Entry saved");
       clearTimeout(cbtResetTimerRef.current);
       cbtResetTimerRef.current = setTimeout(() => cbtMutation.reset(), 3000);
+    },
+    onError: () => {
+      toast.error("Couldn't save entry. Try again.");
     },
   });
 

--- a/frontend/src/hooks/use-dbt.ts
+++ b/frontend/src/hooks/use-dbt.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { apiEnvelopeSchema, apiFetch, splitDateTime, toLocalDateTimeValue } from "../lib";
 import { dbtFormSchema, dbtListSchema } from "../app/core";
 import type { DbtEntry, DbtFormValues } from "../app/core";
@@ -66,8 +67,12 @@ export function useDbt(enabled: boolean) {
       setEditingDbt(null);
       dbtForm.reset(freshDefaults());
       await queryClient.invalidateQueries({ queryKey: ["dbt"] });
+      toast.success("Entry saved");
       clearTimeout(dbtResetTimerRef.current);
       dbtResetTimerRef.current = setTimeout(() => dbtMutation.reset(), 3000);
+    },
+    onError: () => {
+      toast.error("Couldn't save entry. Try again.");
     },
   });
 

--- a/frontend/src/hooks/use-diary.test.tsx
+++ b/frontend/src/hooks/use-diary.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const { toastSuccess, toastError, apiFetch } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+// Mock the network boundary only: apiFetch is the single HTTP call site.
+vi.mock("../lib", async () => {
+  const actual = await vi.importActual<typeof import("../lib")>("../lib");
+  return { ...actual, apiFetch: (...args: unknown[]) => apiFetch(...args) };
+});
+
+import { useDiary } from "./use-diary";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const validEntry = {
+  dateTime: "2026-06-07T10:00",
+  moodLevel: null,
+  depressionLevel: null,
+  anxietyLevel: null,
+  positiveMoods: "",
+  negativeMoods: "",
+  generalMoods: "",
+  description: "",
+  gratitude: "",
+};
+
+describe("useDiary toasts", () => {
+  beforeEach(() => {
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    apiFetch.mockReset();
+  });
+
+  test("fires a success toast when a diary entry saves", async () => {
+    apiFetch.mockResolvedValue({ id: 1 });
+    const { result } = renderHook(() => useDiary(true), { wrapper });
+
+    result.current.diaryMutation.mutate(validEntry);
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith("Entry saved"));
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  test("fires an error toast when the save fails", async () => {
+    apiFetch.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useDiary(true), { wrapper });
+
+    result.current.diaryMutation.mutate(validEntry);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("Couldn't save entry. Try again."));
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/use-diary.ts
+++ b/frontend/src/hooks/use-diary.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { apiEnvelopeSchema, apiFetch, splitDateTime, toLocalDateTimeValue } from "../lib";
 import {
   diaryFormSchema,
@@ -93,8 +94,12 @@ export function useDiary(enabled: boolean) {
         gratitude: "",
       });
       await queryClient.invalidateQueries({ queryKey: ["diary"] });
+      toast.success("Entry saved");
       clearTimeout(diaryResetTimerRef.current);
       diaryResetTimerRef.current = setTimeout(() => diaryMutation.reset(), 3000);
+    },
+    onError: () => {
+      toast.error("Couldn't save entry. Try again.");
     },
   });
 

--- a/frontend/src/hooks/use-pain.ts
+++ b/frontend/src/hooks/use-pain.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { apiEnvelopeSchema, apiFetch, splitDateTime, toLocalDateTimeValue } from "../lib";
 import {
   listToCsv,
@@ -105,8 +106,12 @@ export function usePain(enabled: boolean) {
       setEditingPain(null);
       painForm.reset(createDefaultPainFormValues());
       await queryClient.invalidateQueries({ queryKey: ["pain"] });
+      toast.success("Entry saved");
       clearTimeout(painResetTimerRef.current);
       painResetTimerRef.current = setTimeout(() => painMutation.reset(), 3000);
+    },
+    onError: () => {
+      toast.error("Couldn't save entry. Try again.");
     },
   });
 


### PR DESCRIPTION
## What

Introduces [Sonner](https://sonner.emilkowal.ski/) toasts and wires `toast.success` / `toast.error` into the **diary, pain, CBT and DBT** save mutations (all four structurally-identical entry forms).

## Why

- CBT and DBT had **no `onError` handler at all** — a failed save (network down, 500) was completely silent and looked identical to a success. This closes a real reliability gap, not just a cosmetic one.
- Previously success was signalled only by the submit button briefly showing "✓ Saved" (easy to miss) and errors had no feedback.
- There were **0** native `alert()`/`confirm()` in the codebase (the original roadmap pain point was already gone) and no toast system existed — this adds one.

## Notes

- `<Toaster theme="dark">` is pinned to dark on purpose: the app ships only dark themes (`dark`, `grey`, `oled` — `themeIds` in `app/core.ts`), there is no light mode to follow. `"system"` would show a white toast on an always-dark app.
- MCP token create/revoke intentionally keep their existing inline `InlineMessage` feedback to avoid double-notifying (AGENTS.md §3).
- Toast messages are static literals — no PII / user free-text (§10).
- Tests: contract test (`apiFetch` mocked at the network boundary, `sonner` mocked) asserting success → `toast.success`, failure → `toast.error`.

Reviewed by an Opus review-gate subagent: verdict **pass**. The reviewer's one substantive finding — CBT/DBT lacked toast parity with diary/pain — was applied in this PR. Tests 57/57, lint clean, build green.

Refs #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)