### PR TITLE
fix: codebase analysis findings 2026-06-13

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -15,7 +15,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  id-token: write
   actions: read
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ playwright-report/
 *.suo
 *.sw?
 .DS_Store
+Thumbs.db
 
 # Claude AI config
 .claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS frontend-deps
+FROM oven/bun:1.3.11 AS frontend-deps
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/bun.lock* ./
 RUN bun install --frozen-lockfile
@@ -8,7 +8,7 @@ COPY frontend/ ./
 ENV NODE_OPTIONS="--max-old-space-size=384"
 RUN bun run build
 
-FROM oven/bun:1
+FROM oven/bun:1.3.11
 WORKDIR /app
 
 COPY backend/package.json backend/bun.lock* ./backend/
@@ -25,5 +25,7 @@ ENV HOST=0.0.0.0 \
     DB_PATH=/app/data/health.sqlite
 
 EXPOSE 5555
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD bun --eval "const r=await fetch('http://localhost:5555/api/v1/auth/session');process.exit(r.ok?0:1)"
 USER bun
 CMD ["bun", "--cwd", "backend", "src/server.ts"]

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -9,7 +9,7 @@
         "cookie": "^1.1.1",
         "drizzle-orm": "^0.45.2",
         "exceljs": "^4.4.0",
-        "hono": "^4.12.23",
+        "hono": "^4.12.25",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -23,6 +23,7 @@
   },
   "overrides": {
     "fast-uri": ">=3.1.2",
+    "ip-address": ">=10.1.1",
     "qs": ">=6.15.2",
     "tmp": "^0.2.6",
     "uuid": ">=11.1.1",
@@ -250,7 +251,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -264,7 +265,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,14 +17,15 @@
     "cookie": "^1.1.1",
     "drizzle-orm": "^0.45.2",
     "exceljs": "^4.4.0",
-    "hono": "^4.12.23",
+    "hono": "^4.12.25",
     "zod": "^4.3.6"
   },
   "overrides": {
     "fast-uri": ">=3.1.2",
     "tmp": "^0.2.6",
     "qs": ">=6.15.2",
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "ip-address": ">=10.1.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -47,6 +47,9 @@ app.use("*", async (c, next) => {
   await next();
   c.res.headers.set("X-Content-Type-Options", "nosniff");
   c.res.headers.set("X-Frame-Options", "DENY");
+  c.res.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  c.res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.res.headers.set("Permissions-Policy", "geolocation=(), camera=(), microphone=()");
 });
 
 // Global middleware: CORS
@@ -175,7 +178,7 @@ app.get("*", (c) => {
 
 // Global error handler
 app.onError((err, c) => {
-  console.error(err);
+  console.error(`[${err.name}] ${err.message}`);
   if (err instanceof HTTPException) return err.getResponse();
   if (err instanceof Response) return err;
   return c.json(

--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -133,7 +133,36 @@ export function mergeOptions(current: string[], incoming: string[]): string[] {
   return out;
 }
 
-export function rowsToHealthBackup(diaryRows: any[], painRows: any[]): { diary: any; pain: any } {
+interface DiaryBackupRow {
+  entry_date: string; entry_time: string;
+  mood_level?: number | null; depression_level?: number | null; anxiety_level?: number | null;
+  positive_moods?: string | null; negative_moods?: string | null; general_moods?: string | null;
+  description?: string | null; gratitude?: string | null; reflection?: string | null;
+}
+
+interface PainBackupRow {
+  entry_date: string; entry_time: string;
+  pain_level?: number | null; fatigue_level?: number | null; coffee_count?: number | null;
+  symptoms?: string | null; area?: string | null; activities?: string | null;
+  habits?: string | null; other?: string | null; medicines?: string | null; note?: string | null;
+}
+
+interface PainApiRow {
+  id: number; entryDate: string; entryTime: string;
+  painLevel: number | null; fatigueLevel: number | null; coffeeCount: number | null;
+  area: string | null; symptoms: string | null; activities: string | null;
+  medicines: string | null; habits: string | null; other: string | null;
+  note: string | null; createdAt: string; updatedAt: string;
+}
+
+interface HealthBackupSheet {
+  source: string;
+  imported_at: string;
+  headers: string[];
+  rows: Record<string, string | number | null>[];
+}
+
+export function rowsToHealthBackup(diaryRows: DiaryBackupRow[], painRows: PainBackupRow[]): { diary: HealthBackupSheet; pain: HealthBackupSheet } {
   const diary = {
     source: "health-backend",
     imported_at: new Date().toISOString(),
@@ -179,7 +208,7 @@ export function rowsToHealthBackup(diaryRows: any[], painRows: any[]): { diary: 
   return { diary, pain };
 }
 
-export function painRowToApi(row: any) {
+export function painRowToApi(row: PainApiRow) {
   return {
     id: row.id,
     entryDate: row.entryDate,

--- a/backend/src/mcp/tools/overview.ts
+++ b/backend/src/mcp/tools/overview.ts
@@ -163,6 +163,7 @@ export function registerOverviewTools(server: McpServer, ctx: McpToolContext): v
         )
         SELECT a.v AS va, b.v AS vb
         FROM a INNER JOIN b ON a.d = b.d
+        LIMIT 3650
       `;
 
       type Row = { va: number; vb: number };

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { createMiddleware } from "hono/factory";
-import { eq, and, gt, sql } from "drizzle-orm";
+import { eq, and, gt, isNull, sql } from "drizzle-orm";
 import { env } from "../env.ts";
 import { readCookie } from "../helpers.ts";
 import type { DrizzleDB } from "../db/index.ts";
@@ -18,7 +18,12 @@ export function getSession(db: DrizzleDB, req: Request): SessionData | null {
   const row = db
     .select({ sid: sessions.sid, userId: sessions.userId, email: sessions.email })
     .from(sessions)
-    .where(and(eq(sessions.sid, sid), gt(sessions.expiresAt, sql`datetime('now')`)))
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(and(
+      eq(sessions.sid, sid),
+      gt(sessions.expiresAt, sql`datetime('now')`),
+      isNull(users.disabledAt),
+    ))
     .limit(1)
     .get();
   if (!row) return null;
@@ -59,18 +64,8 @@ export const requireAuth = createMiddleware<{
     return c.json({ error: { code: "UNAUTHORIZED", message: "Authentication required" } }, 401);
   }
 
-  const me = db
-    .select({ id: users.id, email: users.email, name: users.name, disabledAt: users.disabledAt })
-    .from(users)
-    .where(eq(users.id, session.userId))
-    .limit(1)
-    .get();
-  if (!me || me.disabledAt) {
-    return c.json({ error: { code: "UNAUTHORIZED", message: "Authentication required" } }, 401);
-  }
-
-  c.set("userId", me.id);
-  c.set("userEmail", me.email);
+  c.set("userId", session.userId);
+  c.set("userEmail", session.email);
   c.set("sessionSid", session.sid);
   await next();
 });

--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -199,7 +199,7 @@ backup.post("/json/import", async (c) => {
          ON CONFLICT(user_id, field, value) DO NOTHING`
       );
       for (const field of PAIN_MULTI_FIELDS) {
-        const values = (removed as any)[field];
+        const values = (removed as Record<string, unknown>)[field];
         if (!Array.isArray(values)) continue;
         for (const raw of values) {
           const normalized = String(raw).trim();
@@ -226,7 +226,7 @@ backup.post("/json/import", async (c) => {
          ON CONFLICT(user_id, field, value) DO NOTHING`
       );
       for (const field of PAIN_MULTI_FIELDS) {
-        const values = (importedOptions as any)[field];
+        const values = (importedOptions as Record<string, unknown>)[field];
         if (!Array.isArray(values)) continue;
         for (const raw of values) {
           const normalized = String(raw).trim();
@@ -306,7 +306,6 @@ const XLSX_UPLOAD_MAX_BASE64_CHARS = Math.ceil(XLSX_UPLOAD_MAX_BYTES / 3) * 4 + 
 const XLSX_MIME_TYPES = new Set([
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.ms-excel",
-  "application/octet-stream"
 ]);
 
 backup.post("/xlsx/import", async (c) => {
@@ -329,7 +328,7 @@ backup.post("/xlsx/import", async (c) => {
         400
       );
     }
-    if (file.type && !XLSX_MIME_TYPES.has(file.type)) {
+    if (!XLSX_MIME_TYPES.has(file.type)) {
       return c.json(
         { error: { code: "INVALID_FILE_TYPE", message: "Unsupported MIME type" } },
         400
@@ -344,7 +343,7 @@ backup.post("/xlsx/import", async (c) => {
     const arrayBuffer = await file.arrayBuffer();
     await workbook.xlsx.load(arrayBuffer);
   } else {
-    const payload = (await c.req.json().catch(() => null)) as any;
+    const payload = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
     if (!payload?.base64 || typeof payload.base64 !== "string") {
       return c.json({ error: { code: "MISSING_FILE", message: "Expected multipart form upload or JSON {base64}" } }, 400);
     }
@@ -429,6 +428,8 @@ backup.post("/purge", async (c) => {
     rawDb.query(`DELETE FROM dbt_entries WHERE user_id = ?`).run(userId);
     rawDb.query(`DELETE FROM memorable_days WHERE user_id = ?`).run(userId);
     rawDb.query(`DELETE FROM user_preferences WHERE user_id = ?`).run(userId);
+    rawDb.query(`DELETE FROM pain_options WHERE user_id = ?`).run(userId);
+    rawDb.query(`DELETE FROM pain_removed_options WHERE user_id = ?`).run(userId);
   });
   tx();
   return c.json({ data: { ok: true } });

--- a/backend/src/routes/diary.ts
+++ b/backend/src/routes/diary.ts
@@ -53,6 +53,7 @@ diary.get("/", (c) => {
       generalMoods: row.generalMoods ?? "",
       description: row.description ?? "",
       gratitude: row.gratitude ?? "",
+      reflection: row.reflection ?? "",
       createdAt: row.createdAt,
       updatedAt: row.updatedAt
     }))

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -6,7 +6,7 @@ function isoDateRefine(val: string): boolean {
   const parsed = new Date(val);
   if (isNaN(parsed.getTime())) return false;
   const [year, month, day] = val.split("-").map(Number);
-  return parsed.getFullYear() === year && parsed.getMonth() + 1 === month && parsed.getDate() === day;
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() + 1 === month && parsed.getUTCDate() === day;
 }
 
 export const loginSchema = z.object({
@@ -92,7 +92,7 @@ export const prefsSchema = z.object({
   model: z.string().max(200).default(DEFAULT_MODEL),
   chatRange: z.string().default("all"),
   lastRange: z.string().default("all"),
-  graphSelection: z.record(z.string(), z.any()).default({}),
+  graphSelection: z.record(z.string(), z.unknown()).default({}),
   birthday: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(isoDateRefine, {
     message: "Invalid birthday: must be a valid calendar date in YYYY-MM-DD format"
   }).nullable().optional().default(null),
@@ -118,11 +118,13 @@ export const mcpTokenCreateSchema = z.object({
   expiresAt: z.string().datetime().nullable().optional().default(null).refine(
     (val) => {
       if (!val) return true;
+      const ts = new Date(val).getTime();
+      if (ts < Date.now()) return false;
       const max = new Date();
       max.setFullYear(max.getFullYear() + 1);
-      return new Date(val) <= max;
+      return ts <= max.getTime();
     },
-    { message: "Expiry must be within 1 year from now" }
+    { message: "Expiry must be in the future and within 1 year from now" }
   ),
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: health
     network_mode: host
     mem_limit: 512m
+    cpus: "0.5"
     user: "1000:1000"
     environment:
       HOST: 0.0.0.0

--- a/frontend/src/hooks/use-settings.ts
+++ b/frontend/src/hooks/use-settings.ts
@@ -80,7 +80,7 @@ export function useSettings(enabled: boolean) {
   };
 
   const doExportJson = async () => {
-    const payload = await apiFetch("/api/v1/backup/json", { method: "GET" }, (raw) => apiEnvelopeSchema(z.any()).parse(raw).data);
+    const payload = await apiFetch("/api/v1/backup/json", { method: "GET" }, (raw) => apiEnvelopeSchema(z.unknown()).parse(raw).data);
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const anchor = document.createElement("a");
     anchor.href = URL.createObjectURL(blob);
@@ -91,7 +91,12 @@ export function useSettings(enabled: boolean) {
 
   const doImportJson = async (file: File) => {
     const text = await file.text();
-    const parsed = JSON.parse(text);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error("File is not valid JSON");
+    }
     await apiFetch("/api/v1/backup/json/import", { method: "POST", body: JSON.stringify(parsed) }, (raw) =>
       apiEnvelopeSchema(z.object({ ok: z.boolean() })).parse(raw).data,
     );


### PR DESCRIPTION
## Summary

- **Security** — Fix `isoDateRefine` UTC bug (valid dates rejected in non-UTC timezones)
- **Security** — Add missing `reflection` field to diary GET response
- **Security** — XLSX MIME hardening: remove `application/octet-stream` from allowlist; drop truthiness guard so empty Content-Type can't bypass check
- **Security** — Add `pain_options` + `pain_removed_options` to purge transaction (previously left behind after a full purge)
- **Security** — Replace `as any` casts in backup.ts with typed alternatives
- **Security** — Structured error logging: log only `err.name + err.message` instead of full Error object (avoids stack-trace / query PII in prod logs)
- **Security** — Add `Strict-Transport-Security`, `Referrer-Policy`, `Permissions-Policy` HTTP response headers
- **Security** — Reject MCP token `expiresAt` values in the past (schema now enforces future + ≤ 1 year)
- **Security** — Remove over-broad `id-token: write` from `claude-mention.yml` top-level permissions
- **Quality** — `z.any()` → `z.unknown()` in `prefsSchema` and JSON export fetch parser
- **Quality** — `doImportJson`: wrap `JSON.parse` in try/catch with user-friendly error message
- **Quality** — Typed interfaces for `rowsToHealthBackup` / `painRowToApi` in `helpers.ts` (eliminate `any[]`)
- **Performance** — `requireAuth` single JOIN query replacing double round-trip (sessions + users)
- **Performance** — `LIMIT 3650` on Pearson correlation SQL to bound memory for "all" period
- **Infrastructure** — Pin Dockerfile to `oven/bun:1.3.11` (was floating `oven/bun:1`)
- **Infrastructure** — Add `HEALTHCHECK` instruction to Dockerfile (was only in docker-compose)
- **Infrastructure** — Add `cpus: "0.5"` to docker-compose to cap CPU alongside existing `mem_limit`
- **Infrastructure** — Add `ip-address >= 10.1.1` override (XSS in `Address6` HTML methods)
- **Infrastructure** — Bump `hono` to `^4.12.25` (covers 16 advisories: cache leakage, cookie injection, bodyLimit bypass, JWT scheme bypass, IP restriction bypass, path traversal)
- **Infrastructure** — Add `Thumbs.db` to `.gitignore`

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/health/issues/165

## Sub-analyst reports

- **Security**: MIME bypass via client-supplied Content-Type (SHIPPED); PAT stored with unsalted SHA-256 (DEFERRED — KDF choice); no rate limiting on login (DEFERRED — architecture)
- **Quality**: `reflection` field missing from diary GET (SHIPPED); `any` types in helpers (SHIPPED); misleading `settings-mockups.tsx` filename (DEFERRED — cross-file rename)
- **Bugs**: UTC getter bug in `isoDateRefine` (SHIPPED); purge incomplete (SHIPPED); MIME guard bypass (SHIPPED); monthly recurring day-31 silent skip (DEFERRED — product decision)
- **Tests**: Zero tests for MCP PAT auth middleware (DEFERRED — test gap); zero tests for purge endpoint (DEFERRED — test gap); CBT/DBT date filter untested (DEFERRED)
- **Deps**: `hono` 16 advisories (SHIPPED); `esbuild` RCE via drizzle-kit (DEFERRED — drizzle-kit bump touches lockfile integrity); `fast-uri` path traversal (existing overrides applied); `ip-address` XSS (SHIPPED override)
- **Performance**: Full-table unbounded SELECTs on diary/pain GET (DEFERRED — requires pagination strategy); double auth query consolidated to JOIN (SHIPPED); `getComputedStyle` in `useMemo` (DEFERRED)

---
Generated automatically by Codebase Analyst — 2026-06-13