### PR TITLE
refactor: rename settings-mockups.tsx to SettingsPanel.tsx

### DIFF
--- a/frontend/src/app/SettingsPanel.tsx
+++ b/frontend/src/app/SettingsPanel.tsx
@@ -259,7 +259,7 @@ const settingsTabs: { id: SettingsTab; label: string; danger?: boolean }[] = [
   { id: "danger", label: "Danger zone", danger: true },
 ];
 
-export function SettingsVariantB(props: SettingsSectionProps) {
+export function SettingsPanel(props: SettingsSectionProps) {
   const [tab, setTab] = useState<SettingsTab>("account");
   return (
     <div className="settings-mock settings-mock-b">

--- a/frontend/src/app/SettingsSection.tsx
+++ b/frontend/src/app/SettingsSection.tsx
@@ -1,6 +1,6 @@
 import type { useAuth } from "../hooks/use-auth";
 import { type InlineMessage } from "./core";
-import { SettingsVariantB } from "./settings-mockups";
+import { SettingsPanel } from "./SettingsPanel";
 
 export function SettingsSection({
   auth,
@@ -52,7 +52,7 @@ export function SettingsSection({
   return (
     <section className="panel panel--frameless">
       <h1 className="panel-title">Settings</h1>
-      <SettingsVariantB {...variantProps} />
+      <SettingsPanel {...variantProps} />
     </section>
   );
 }


### PR DESCRIPTION
Addresses the `settings-mockups-filename` deferred finding from #165.

The production Settings component lived in `settings-mockups.tsx` and exported `SettingsVariantB` — misleading leftovers from a mockup phase. Renames the file to `SettingsPanel.tsx` (PascalCase, matching its sibling `SettingsSection.tsx`) and the export to `SettingsPanel`, updating the single importer.

I used PascalCase rather than the kebab `settings-panel.tsx` the finding suggested, because the `app/` directory is predominantly PascalCase for components (17 vs 5) and the sibling is `SettingsSection.tsx`.

Frontend build + lint green. Part of #165.