### PR TITLE
chore: bridge networking + bundle warning limit

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,8 +1,12 @@
 services:
   health:
     command: ["bun", "--cwd", "backend", "--watch", "src/server.ts"]
+    # Under bridge networking the host's Vite dev server is reached via the
+    # host-gateway alias, not the container's own 127.0.0.1.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
-      DEV_FRONTEND_PROXY_URL: ${DEV_FRONTEND_PROXY_URL:-http://127.0.0.1:5173}
+      DEV_FRONTEND_PROXY_URL: ${DEV_FRONTEND_PROXY_URL:-http://host.docker.internal:5173}
     volumes:
       - ./backend/src:/app/backend/src
       - ./backend/package.json:/app/backend/package.json:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     build: .
     image: health:local
     container_name: health
-    network_mode: host
+    ports:
+      - "5555:5555"
     mem_limit: 512m
     cpus: "0.5"
     user: "1000:1000"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,12 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  build: {
+    // Sections, the wellbeing chart, and the emoji-heavy memorable-days view are
+    // already React.lazy-split; the only chunk over 500 kB is memorable-days,
+    // whose bulk is the intrinsic emojibase dataset loaded on demand.
+    chunkSizeWarningLimit: 650,
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Two follow-up hardening/clean-up items.

### 1. Docker networking: `host` → bridge (H3)

**Investigation:** the container is fully self-contained.
- DB is SQLite local file (`bun:sqlite`, `DB_PATH=/app/data/health.sqlite`, mounted volume) — no host DB.
- No ollama/LLM/external service. The only outbound `fetch` is `proxyDevFrontend`, gated on `DEV_FRONTEND_PROXY_URL`, which is empty in the production compose and only set in the dev override.
- Server listens on `PORT 5555` (`HOST 0.0.0.0`); Dockerfile already `EXPOSE 5555`.

**Decision:** converted to bridge with an explicit `ports: 5555:5555` (host port preserved). Host networking was a template default with no production justification; bridge isolates the container.

The dev override (`docker-compose.dev.yml`) was the only thing relying on host mode — it proxied the host's Vite dev server via the container's `127.0.0.1:5173`. Repointed it at `host.docker.internal:5173` with an `extra_hosts: host-gateway` mapping so `dev:docker` keeps working under bridge.

Both compose files validated: `docker compose config -q` passes for prod and prod+dev.

### 2. Frontend bundle

The codebase is already aggressively code-split (React.lazy + Suspense on every nav section, the wellbeing chart, and the memorable-days view). The only chunk over the 500 kB default is `memorable-days` (586 kB), whose bulk is the intrinsic `emojibase` dataset loaded on demand when that already-lazy section opens. Splitting the dataset deeper would mean refactoring a hot component (focus trap, scroll restore, keyboard nav) for marginal gain on a single-user app, so raised `build.chunkSizeWarningLimit` to 650 kB with a justification comment instead.

## Verification

- backend: `bun run typecheck` clean, `bun run test` 229 pass / 0 fail
- frontend: `bun run build` no chunk-size warning, `bun run lint` clean, `bun run test` 79 pass
- compose: `docker compose config -q` passes (prod and prod+dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)