### PR TITLE
refactor(#171): Tailwind numeric spacing, tokenized breakpoints/focus, design-system prune

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -269,7 +269,7 @@ function App() {
 
   return (
     <>
-    <div className={`grid grid-cols-[220px_1fr] min-h-screen transition-[grid-template-columns] duration-[250ms] ease-[ease] max-[720px]:grid-cols-1 ${sidebarCollapsed ? "min-[721px]:grid-cols-[62px_1fr]" : ""} ${mobileSidebarOpen ? "max-[720px]:h-[100dvh] max-[720px]:overflow-hidden" : ""}`}>
+    <div className={`grid grid-cols-[220px_1fr] min-h-screen transition-[grid-template-columns] duration-[250ms] ease-[ease] max-mobile:grid-cols-1 ${sidebarCollapsed ? "mobile:grid-cols-[62px_1fr]" : ""} ${mobileSidebarOpen ? "max-mobile:h-[100dvh] max-mobile:overflow-hidden" : ""}`}>
       <Sidebar
         nav={nav}
         onNav={(item) => { setNav(item); setMobileSidebarOpen(false); }}
@@ -279,10 +279,10 @@ function App() {
         mobileOpen={mobileSidebarOpen}
       />
 
-      <main className={`max-w-[1500px] w-full overflow-y-auto [padding:clamp(var(--spacing-stack),3vw,var(--spacing-split))_clamp(var(--spacing-stack),3vw,var(--spacing-split))_var(--spacing-block)] max-[720px]:p-stack ${mobileSidebarOpen ? "max-[720px]:overflow-hidden" : ""}`}>
+      <main className={`max-w-[1500px] w-full overflow-y-auto [padding:clamp(12px,3vw,48px)_clamp(12px,3vw,48px)_20px] max-mobile:p-3 ${mobileSidebarOpen ? "max-mobile:overflow-hidden" : ""}`}>
         <button
           type="button"
-          className="mobile-menu-btn hidden max-[720px]:flex max-[720px]:items-center max-[720px]:justify-center w-[40px] h-[40px] max-[720px]:mb-stack max-[720px]:ml-inline p-0 border-0 rounded-sm bg-card-soft text-muted cursor-pointer shadow-none hover:text-text hover:bg-card-strong"
+          className="mobile-menu-btn hidden max-mobile:flex max-mobile:items-center max-mobile:justify-center w-[40px] h-[40px] max-mobile:mb-3 max-mobile:ml-2 p-0 border-0 rounded-sm bg-card-soft text-muted cursor-pointer shadow-none hover:text-text hover:bg-card-strong"
           onClick={() => setMobileSidebarOpen(true)}
           aria-label="Open menu"
         >

--- a/frontend/src/app/CbtSection.tsx
+++ b/frontend/src/app/CbtSection.tsx
@@ -25,7 +25,7 @@ import {
 } from "./entries";
 
 const DATETIME_FIELD =
-  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-inline [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
+  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-2 [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
 
 export function CbtSection({
   cbtForm,
@@ -117,13 +117,13 @@ export function CbtSection({
   } = useDiaryColumnCap(cbtEntries, isLoading);
 
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">CBT Thought Response</h1>
-      <div className="grid gap-page min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-split min-[1100px]:items-start">
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">CBT Thought Response</h1>
+      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
         <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
           <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
-          <form className="mb-inline" onSubmit={cbtForm.handleSubmit(onSubmit)}>
-            <div className="grid gap-stack content-start min-w-0">
+          <form className="mb-2" onSubmit={cbtForm.handleSubmit(onSubmit)}>
+            <div className="grid gap-3 content-start min-w-0">
               <FieldLine
                 label="Date & time"
                 type="datetime-local"
@@ -150,15 +150,15 @@ export function CbtSection({
                 />
               ))}
               {editingCbt ? (
-                <div className="flex gap-inline flex-wrap">
+                <div className="flex gap-2 flex-wrap">
                   <Button type="button" onClick={onCancelEdit}>
                     Cancel edit
                   </Button>
                 </div>
               ) : null}
             </div>
-            <div className="flex justify-end pt-inline">
-              <Button type="submit" variant={cbtMutationState.isSuccess ? "success" : "primary"} className="mb-block">
+            <div className="flex justify-end pt-2">
+              <Button type="submit" variant={cbtMutationState.isSuccess ? "success" : "primary"} className="mb-5">
                 {cbtMutationState.isSuccess ? "✓ Saved" : editingCbt ? "Update entry" : "Save entry"}
               </Button>
             </div>

--- a/frontend/src/app/CbtSection.tsx
+++ b/frontend/src/app/CbtSection.tsx
@@ -118,10 +118,10 @@ export function CbtSection({
 
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">CBT Thought Response</h1>
-      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
-        <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
-          <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">CBT Thought Response</h1>
+      <div className="grid gap-8 wide:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] wide:gap-12 wide:items-start">
+        <div className="min-w-0 max-wide:border-b max-wide:border-border" ref={leftColRef}>
+          <EntriesHeading className="wide:mt-0">New entry</EntriesHeading>
           <form className="mb-2" onSubmit={cbtForm.handleSubmit(onSubmit)}>
             <div className="grid gap-3 content-start min-w-0">
               <FieldLine

--- a/frontend/src/app/DashboardSection.tsx
+++ b/frontend/src/app/DashboardSection.tsx
@@ -20,14 +20,14 @@ import { DateInput } from "../components/ui/DateInput";
 const WellbeingChart = lazy(() => import("./WellbeingChart"));
 
 const DASH_CARD =
-  "grid grid-rows-[auto_auto_22px] gap-inline content-start w-full max-w-[200px] justify-self-start rounded-md p-stack bg-card-soft";
+  "grid grid-rows-[auto_auto_22px] gap-2 content-start w-full max-w-[200px] justify-self-start rounded-md p-3 bg-card-soft";
 const CARD_H3 =
   "m-0 text-nano font-bold tracking-[0.12em] uppercase text-muted leading-tight whitespace-nowrap overflow-hidden text-ellipsis translate-y-0.5";
 const CARD_VALUE = "text-lg font-bold text-text translate-y-0.5";
 const DELTA_SLOT = "min-h-6 flex items-end translate-y-0.5";
-const DELTA_BASE = "inline-flex items-center rounded-full px-inline py-0.5 text-micro font-bold self-end";
+const DELTA_BASE = "inline-flex items-center rounded-full px-2 py-0.5 text-micro font-bold self-end";
 const QUICK_RANGE_BASE =
-  "px-stack py-tight text-xs font-semibold font-body border-0 rounded-full cursor-pointer transition-[color,background] duration-150 ease-[ease] shadow-none";
+  "px-3 py-1 text-xs font-semibold font-body border-0 rounded-full cursor-pointer transition-[color,background] duration-150 ease-[ease] shadow-none";
 const QUICK_RANGE_IDLE =
   "text-muted bg-[color-mix(in_srgb,var(--text)_5%,transparent)] hover:text-text hover:bg-[color-mix(in_srgb,var(--text)_10%,transparent)] [[data-theme=oled]_&]:bg-card-soft [[data-theme=oled]_&]:hover:bg-[color-mix(in_srgb,white_8%,var(--card-soft))]";
 const QUICK_RANGE_ACTIVE = "text-accent bg-[color-mix(in_srgb,var(--accent)_15%,transparent)]";
@@ -73,19 +73,19 @@ export function DashboardSection({
   anniversaryCards: MemorableDay[];
 }) {
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Dashboard</h1>
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Dashboard</h1>
 
-      <div className="flex flex-wrap gap-stack items-end mb-block">
-        <label className="flex flex-col gap-inline">
+      <div className="flex flex-wrap gap-3 items-end mb-5">
+        <label className="flex flex-col gap-2">
           <span className={FIELD_LINE_LABEL}>From</span>
           <DateInput value={dashboardFrom} onChange={(v) => onDateChange("from", v)} ariaLabel="From date" />
         </label>
-        <label className="flex flex-col gap-inline">
+        <label className="flex flex-col gap-2">
           <span className={FIELD_LINE_LABEL}>To</span>
           <DateInput value={dashboardTo} onChange={(v) => onDateChange("to", v)} ariaLabel="To date" />
         </label>
-        <div className="flex gap-inline flex-wrap">
+        <div className="flex gap-2 flex-wrap">
           {dashboardQuickRanges.map((range) => (
             <button
               type="button"
@@ -116,7 +116,7 @@ export function DashboardSection({
           {anniversaryCards.length > 0 ? (
             <>
               <SectionHead title="Anniversaries today" variant="dashboard" />
-              <div className="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-stack">
+              <div className="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-3">
                 {anniversaryCards.map((card) => (
                   <article key={`${card.source}-${card.id}-${card.date}`} className={DASH_CARD}>
                     <h3 className={CARD_H3}>
@@ -136,7 +136,7 @@ export function DashboardSection({
           ) : null}
 
           <SectionHead title="Averages" variant="dashboard" />
-          <div data-testid="averages" className="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-stack">
+          <div data-testid="averages" className="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-3">
             {dashboardCards.map((card) => {
               const deltaPct = calcDeltaPercent(card.value, card.previous);
               const delta = deltaPct === null ? null : formatDelta(deltaPct, Boolean(card.invertDelta));
@@ -164,9 +164,9 @@ export function DashboardSection({
           </div>
 
           <SectionHead title="Metrics over time" variant="dashboard" />
-          <div className="grid gap-stack p-stack rounded-md bg-card-soft mt-stack">
-            <div className="flex justify-between items-start gap-inline flex-wrap">
-              <div className="flex flex-wrap gap-inline">
+          <div className="grid gap-3 p-3 rounded-md bg-card-soft mt-3">
+            <div className="flex justify-between items-start gap-2 flex-wrap">
+              <div className="flex flex-wrap gap-2">
                 {wellbeingSeries.map((series) => {
                   const checked = graphSelection[series.key] ?? true;
                   const hasData = series.points.length > 0;
@@ -174,7 +174,7 @@ export function DashboardSection({
                     <label
                       key={series.key}
                       data-testid="series-toggle"
-                      className={`inline-flex items-center gap-inline border-0 rounded-full px-stack py-tight bg-card-soft text-micro font-semibold leading-none shadow-none${hasData ? "" : " opacity-50"}`}
+                      className={`inline-flex items-center gap-2 border-0 rounded-full px-3 py-1 bg-card-soft text-micro font-semibold leading-none shadow-none${hasData ? "" : " opacity-50"}`}
                       style={{ "--series-color": series.color } as CSSProperties}
                     >
                       <input
@@ -204,12 +204,12 @@ export function DashboardSection({
             )}
           </div>
 
-          <div className="grid grid-cols-[repeat(2,minmax(0,1fr))] gap-block items-start @max-[720px]:grid-cols-1">
-            <section className="grid gap-stack">
+          <div className="grid grid-cols-[repeat(2,minmax(0,1fr))] gap-5 items-start @max-mobile:grid-cols-1">
+            <section className="grid gap-3">
               <SectionHead title="At a glance" variant="dashboard" />
-              <div data-testid="insights" className="grid gap-stack">
+              <div data-testid="insights" className="grid gap-3">
                 {dashboardInsights.map((insight) => (
-                  <div key={insight.title} className="grid gap-tight">
+                  <div key={insight.title} className="grid gap-1">
                     <strong className="text-muted text-nano font-bold tracking-[0.16em] uppercase">{insight.title}</strong>
                     <p className="m-0 text-text text-control leading-normal">{insight.detail}</p>
                   </div>
@@ -217,21 +217,21 @@ export function DashboardSection({
               </div>
             </section>
 
-            <section className="grid gap-stack">
+            <section className="grid gap-3">
               <SectionHead title="Patterns" variant="dashboard" />
               {dashboardConnections.length > 0 ? (
-                <div className="grid gap-stack">
+                <div className="grid gap-3">
                   {dashboardConnections.map((connection) => (
-                    <article key={connection.title} className="grid gap-inline rounded-md p-stack bg-card-soft">
+                    <article key={connection.title} className="grid gap-2 rounded-md p-3 bg-card-soft">
                       <span className="text-nano font-bold tracking-[0.16em] uppercase text-muted">{connection.title}</span>
                       <strong className="m-0 text-text text-control font-semibold">{connection.summary}</strong>
                       <p className="m-0 text-muted text-control leading-normal">{connection.detail}</p>
-                      <span className={`justify-self-start rounded-full px-inline py-0.5 text-micro font-bold ${CONFIDENCE_TONE[connection.confidence] ?? CONFIDENCE_TONE.weak}`}>{connection.confidence} confidence</span>
+                      <span className={`justify-self-start rounded-full px-2 py-0.5 text-micro font-bold ${CONFIDENCE_TONE[connection.confidence] ?? CONFIDENCE_TONE.weak}`}>{connection.confidence} confidence</span>
                     </article>
                   ))}
                 </div>
               ) : (
-                <div className="grid gap-inline m-0">
+                <div className="grid gap-2 m-0">
                   <p className="text-control font-semibold text-text m-0">No connection signals yet</p>
                   <p className="max-w-[60ch] text-control text-muted leading-normal m-0">Log more overlapping diary and pain entries to unlock pattern cards here.</p>
                 </div>

--- a/frontend/src/app/DashboardSection.tsx
+++ b/frontend/src/app/DashboardSection.tsx
@@ -22,10 +22,10 @@ const WellbeingChart = lazy(() => import("./WellbeingChart"));
 const DASH_CARD =
   "grid grid-rows-[auto_auto_22px] gap-inline content-start w-full max-w-[200px] justify-self-start rounded-md p-stack bg-card-soft";
 const CARD_H3 =
-  "m-0 text-nano font-bold tracking-[0.12em] uppercase text-muted leading-tight whitespace-nowrap overflow-hidden text-ellipsis translate-y-[2px]";
-const CARD_VALUE = "text-lg font-bold text-text translate-y-[2px]";
-const DELTA_SLOT = "min-h-[22px] flex items-end translate-y-[2px]";
-const DELTA_BASE = "inline-flex items-center rounded-full px-inline py-[2px] text-micro font-bold self-end";
+  "m-0 text-nano font-bold tracking-[0.12em] uppercase text-muted leading-tight whitespace-nowrap overflow-hidden text-ellipsis translate-y-0.5";
+const CARD_VALUE = "text-lg font-bold text-text translate-y-0.5";
+const DELTA_SLOT = "min-h-6 flex items-end translate-y-0.5";
+const DELTA_BASE = "inline-flex items-center rounded-full px-inline py-0.5 text-micro font-bold self-end";
 const QUICK_RANGE_BASE =
   "px-stack py-tight text-xs font-semibold font-body border-0 rounded-full cursor-pointer transition-[color,background] duration-150 ease-[ease] shadow-none";
 const QUICK_RANGE_IDLE =
@@ -226,7 +226,7 @@ export function DashboardSection({
                       <span className="text-nano font-bold tracking-[0.16em] uppercase text-muted">{connection.title}</span>
                       <strong className="m-0 text-text text-control font-semibold">{connection.summary}</strong>
                       <p className="m-0 text-muted text-control leading-normal">{connection.detail}</p>
-                      <span className={`justify-self-start rounded-full px-inline py-[2px] text-micro font-bold ${CONFIDENCE_TONE[connection.confidence] ?? CONFIDENCE_TONE.weak}`}>{connection.confidence} confidence</span>
+                      <span className={`justify-self-start rounded-full px-inline py-0.5 text-micro font-bold ${CONFIDENCE_TONE[connection.confidence] ?? CONFIDENCE_TONE.weak}`}>{connection.confidence} confidence</span>
                     </article>
                   ))}
                 </div>

--- a/frontend/src/app/DashboardSection.tsx
+++ b/frontend/src/app/DashboardSection.tsx
@@ -204,7 +204,7 @@ export function DashboardSection({
             )}
           </div>
 
-          <div className="grid grid-cols-[repeat(2,minmax(0,1fr))] gap-5 items-start @max-mobile:grid-cols-1">
+          <div className="grid grid-cols-[repeat(2,minmax(0,1fr))] gap-5 items-start @max-[720px]:grid-cols-1">
             <section className="grid gap-3">
               <SectionHead title="At a glance" variant="dashboard" />
               <div data-testid="insights" className="grid gap-3">

--- a/frontend/src/app/DashboardSection.tsx
+++ b/frontend/src/app/DashboardSection.tsx
@@ -74,7 +74,7 @@ export function DashboardSection({
 }) {
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Dashboard</h1>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Dashboard</h1>
 
       <div className="flex flex-wrap gap-3 items-end mb-5">
         <label className="flex flex-col gap-2">

--- a/frontend/src/app/DbtSection.tsx
+++ b/frontend/src/app/DbtSection.tsx
@@ -25,9 +25,9 @@ import {
 } from "./entries";
 
 const DATETIME_FIELD =
-  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-inline [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
+  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-2 [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
 const THERAPY_CALLOUT =
-  "m-0 px-stack py-inline bg-card-soft border-l-2 border-[color-mix(in_srgb,var(--accent)_50%,transparent)] rounded-sm text-muted text-hint leading-normal";
+  "m-0 px-3 py-2 bg-card-soft border-l-2 border-[color-mix(in_srgb,var(--accent)_50%,transparent)] rounded-sm text-muted text-hint leading-normal";
 
 export function DbtSection({
   dbtForm,
@@ -124,13 +124,13 @@ export function DbtSection({
   ];
 
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">DBT Distress Tolerance</h1>
-      <div className="grid gap-page min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-split min-[1100px]:items-start">
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">DBT Distress Tolerance</h1>
+      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
         <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
           <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
-          <form className="mb-inline" onSubmit={dbtForm.handleSubmit(onSubmit)}>
-            <div className="grid gap-stack content-start min-w-0">
+          <form className="mb-2" onSubmit={dbtForm.handleSubmit(onSubmit)}>
+            <div className="grid gap-3 content-start min-w-0">
               <FieldLine
                 label="Date & time"
                 type="datetime-local"
@@ -143,7 +143,7 @@ export function DbtSection({
                 }}
               />
               {dbtGroups.map((g) => (
-                <div key={g.title} className="flex flex-col gap-stack">
+                <div key={g.title} className="flex flex-col gap-3">
                   <SectionHead title={g.title} variant="ds" />
                   {g.callouts?.map((c) => (
                     <p key={c} className={THERAPY_CALLOUT}>{c}</p>
@@ -163,19 +163,19 @@ export function DbtSection({
                   ))}
                 </div>
               ))}
-              <p className={`${THERAPY_CALLOUT} mt-stack`}>
+              <p className={`${THERAPY_CALLOUT} mt-3`}>
                 When the emotion comes back, that's ok. Emotions come and go — watch it again, float with the wave.
               </p>
               {editingDbt ? (
-                <div className="flex gap-inline flex-wrap">
+                <div className="flex gap-2 flex-wrap">
                   <Button type="button" onClick={onCancelEdit}>
                     Cancel edit
                   </Button>
                 </div>
               ) : null}
             </div>
-            <div className="flex justify-end pt-inline">
-              <Button type="submit" variant={dbtMutationState.isSuccess ? "success" : "primary"} className="mb-block">
+            <div className="flex justify-end pt-2">
+              <Button type="submit" variant={dbtMutationState.isSuccess ? "success" : "primary"} className="mb-5">
                 {dbtMutationState.isSuccess ? "✓ Saved" : editingDbt ? "Update entry" : "Save entry"}
               </Button>
             </div>

--- a/frontend/src/app/DbtSection.tsx
+++ b/frontend/src/app/DbtSection.tsx
@@ -125,10 +125,10 @@ export function DbtSection({
 
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">DBT Distress Tolerance</h1>
-      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
-        <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
-          <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">DBT Distress Tolerance</h1>
+      <div className="grid gap-8 wide:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] wide:gap-12 wide:items-start">
+        <div className="min-w-0 max-wide:border-b max-wide:border-border" ref={leftColRef}>
+          <EntriesHeading className="wide:mt-0">New entry</EntriesHeading>
           <form className="mb-2" onSubmit={dbtForm.handleSubmit(onSubmit)}>
             <div className="grid gap-3 content-start min-w-0">
               <FieldLine

--- a/frontend/src/app/DesignSystemSection.tsx
+++ b/frontend/src/app/DesignSystemSection.tsx
@@ -31,28 +31,12 @@ const DESIGN_COLOR_TOKENS: { name: string; varName: string; role: string }[] = [
   { name: "Border", varName: "--border", role: "Dividers" },
   { name: "Border soft", varName: "--border-soft", role: "Hairlines" },
   { name: "Accent", varName: "--accent", role: "Primary action" },
-  { name: "Accent 2", varName: "--accent-2", role: "Accent hover" },
   { name: "Success", varName: "--success", role: "Positive state" },
   { name: "Warning", varName: "--warning", role: "Mid state" },
   { name: "Danger", varName: "--danger", role: "Negative state" },
 ];
 
-const DESIGN_SPACING_TOKENS: { varName: string; px: string }[] = [
-  { varName: "--spacing-tight", px: "4px" },
-  { varName: "--spacing-inline", px: "8px" },
-  { varName: "--spacing-stack", px: "12px" },
-  { varName: "--spacing-block", px: "20px" },
-  { varName: "--spacing-page", px: "30px" },
-  { varName: "--spacing-split", px: "48px" },
-];
-
 const DS_MEMORABLE_WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
-
-const DESIGN_RADIUS_TOKENS: { varName: string; px: string }[] = [
-  { varName: "--radius-sm", px: "10px" },
-  { varName: "--radius-md", px: "12px" },
-  { varName: "--radius-lg", px: "16px" },
-];
 
 const DS_SIDEBAR_DEMO_ICON = (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden width={20} height={20}>
@@ -67,22 +51,22 @@ export function DesignSystemSection() {
   const [tabDemo, setTabDemo] = useState<"positive" | "negative" | "general">("positive");
 
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Design System</h1>
-      <p className="text-muted text-control mt-inline mb-block max-w-[72ch] [&_code]:px-[6px] [&_code]:py-[1px] [&_code]:rounded-[6px] [&_code]:bg-card-soft [&_code]:text-text">
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Design System</h1>
+      <p className="text-muted text-control mt-2 mb-5 max-w-[72ch] [&_code]:px-[6px] [&_code]:py-[1px] [&_code]:rounded-[6px] [&_code]:bg-card-soft [&_code]:text-text">
         Living reference for tokens, primitives, and patterns used across Diary, Pain, therapy forms, and Memorable days.
         Examples use the same classes as production &mdash; edit <code>styles.css</code> and this page tracks it.
       </p>
 
-      <div className="grid gap-page mt-page items-start min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-split">
-        <div className="block min-w-0 [&>section+section]:mt-stack">
-          <EntriesHeading className="mt-0 mb-block">Foundations</EntriesHeading>
+      <div className="grid gap-8 mt-8 items-start min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12">
+        <div className="block min-w-0 [&>section+section]:mt-3">
+          <EntriesHeading className="mt-0 mb-5">Foundations</EntriesHeading>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Colors" aside="CSS custom properties" variant="ds" />
-            <ul className="list-none m-0 p-0 grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-stack">
+            <ul className="list-none m-0 p-0 grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-3">
               {DESIGN_COLOR_TOKENS.map((t) => (
-                <li key={t.varName} className="flex items-center gap-stack p-inline rounded-sm bg-card-soft">
+                <li key={t.varName} className="flex items-center gap-3 p-2 rounded-sm bg-card-soft">
                   <span className="w-[32px] h-[32px] rounded-[8px] flex-shrink-0" style={{ background: `var(${t.varName})` }} />
                   <div className="flex flex-col gap-[2px] min-w-0">
                     <span className="text-xs font-semibold text-text">{t.name}</span>
@@ -94,9 +78,9 @@ export function DesignSystemSection() {
             </ul>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Typography" aside="Manrope" variant="ds" />
-            <dl className="m-0 flex flex-col gap-stack">
+            <dl className="m-0 flex flex-col gap-3">
               <div className="flex flex-col gap-[2px] py-[2px] [&_dt]:m-0 [&_dt]:min-w-0 [&_dd]:m-0 [&_dd]:text-micro [&_dd]:text-muted-soft">
                 <dt style={{ font: "700 28px var(--font-body)" }}>Panel title</dt>
                 <dd>28 / 700</dd>
@@ -124,46 +108,9 @@ export function DesignSystemSection() {
             </dl>
           </section>
 
-          <section className="flex flex-col gap-stack">
-            <SectionHead title="Spacing" aside="Layout tokens" variant="ds" />
-            <p className="text-muted text-control m-0 mb-stack max-w-[62ch] [&_code]:px-[6px] [&_code]:py-[1px] [&_code]:rounded-[6px] [&_code]:bg-card-soft [&_code]:text-text">
-              Use named steps from <code>--spacing-tight</code> (4px) through <code>--spacing-split</code> — no numbered scale; bar length matches each variable.
-            </p>
-            <ul className="list-none m-0 p-0 flex flex-col gap-inline">
-              {DESIGN_SPACING_TOKENS.map((t) => (
-                <li key={t.varName} className="grid grid-cols-[minmax(13rem,auto)_3rem_minmax(0,1fr)] items-center gap-inline text-micro text-muted [&_code]:text-micro [&_code]:text-muted-soft">
-                  <code>{t.varName}</code>
-                  <span className="text-micro text-muted tabular-nums">{t.px}</span>
-                  <span className="h-[8px] bg-accent rounded-[4px] max-w-full min-w-0" style={{ width: `var(${t.varName})` }} aria-hidden title={t.varName} />
-                </li>
-              ))}
-            </ul>
-            <div className="max-w-[320px]">
-              <p className="mt-stack mb-inline text-control font-semibold text-text">Field-line (label ↔ control)</p>
-              <FieldLine label="Example" type="text" defaultValue="Spacing demo" aria-label="Field-line spacing demo" />
-              <p className="mt-[10px] text-micro text-muted-soft leading-normal max-w-[42ch] [&_code]:text-muted">
-                <code>.field-line</code> stacks an uppercase micro-label over a borderless tinted control, with{" "}
-                <strong>gap-inline</strong> between them — the same primitive the production forms use.
-              </p>
-            </div>
-          </section>
-
-          <section className="flex flex-col gap-stack">
-            <SectionHead title="Radius" aside="Rounded corners" variant="ds" />
-            <ul className="list-none m-0 p-0 flex flex-wrap gap-stack">
-              {DESIGN_RADIUS_TOKENS.map((t) => (
-                <li key={t.varName} className="flex flex-col items-center gap-tight text-micro text-muted">
-                  <span className="w-[54px] h-[54px] bg-card-strong" style={{ borderRadius: `var(${t.varName})` }} />
-                  <code>{t.varName}</code>
-                  <span className="text-muted-soft tabular-nums">{t.px}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Badges" aside="9-point scale" variant="ds" />
-            <div className="flex gap-inline flex-wrap">
+            <div className="flex gap-2 flex-wrap">
               <PainBadge variant="low" sm>2</PainBadge>
               <PainBadge variant="mid" sm>5</PainBadge>
               <PainBadge variant="high" sm>8</PainBadge>
@@ -172,12 +119,12 @@ export function DesignSystemSection() {
           </section>
         </div>
 
-        <div className="block min-w-0 [&>section+section]:mt-stack min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-split">
-          <EntriesHeading className="mt-0 mb-block">Components</EntriesHeading>
+        <div className="block min-w-0 [&>section+section]:mt-3 min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-12">
+          <EntriesHeading className="mt-0 mb-5">Components</EntriesHeading>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Buttons" aside="Pill utility" variant="ds" />
-            <div className="flex gap-inline flex-wrap">
+            <div className="flex gap-2 flex-wrap">
               <Button>Default</Button>
               <Button variant="primary">Primary</Button>
               <Button variant="success">✓ Saved</Button>
@@ -185,12 +132,12 @@ export function DesignSystemSection() {
             </div>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Sidebar nav" aside=".sidebar-item" variant="ds" />
             <p className="m-0 text-micro text-muted-soft leading-snug [&_code]:text-muted">
               Uses production classes. Default → hover <code>card-strong</code>; <code>active</code> → accent tint.
             </p>
-            <div className="max-w-[220px] flex flex-col gap-stack">
+            <div className="max-w-[220px] flex flex-col gap-3">
               <button type="button" className={`${NAV_ITEM} ${NAV_ITEM_IDLE}`} tabIndex={-1}>
                 {DS_SIDEBAR_DEMO_ICON}
                 <span className="opacity-100">Dashboard</span>
@@ -202,25 +149,25 @@ export function DesignSystemSection() {
             </div>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Form fields" aside="Field-line" variant="ds" />
-            <div className="flex flex-col gap-stack">
+            <div className="flex flex-col gap-3">
               <FieldLine label="Text" type="text" defaultValue="Sample value" aria-label="Text" />
               <FieldLine label="Date & time" type="datetime-local" defaultValue="2026-04-18T17:30" aria-label="Date/time" className="!w-auto justify-self-start" />
               <FieldLine label="Description" multiline rows={2} placeholder="Free text area…" aria-label="Description" />
             </div>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Metrics" aside="BarMetric · Stepper" variant="ds" />
-            <div className="flex flex-col gap-inline">
+            <div className="flex flex-col gap-2">
               <BarMetric label="Mood" value={moodDemo} fractionDigits={1} higherIsBetter onChange={setMoodDemo} />
               <BarMetric label="Pain" value={painDemo} onChange={setPainDemo} />
               <CoffeeStepper value={coffeeDemo} onChange={setCoffeeDemo} />
             </div>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Tabs" aside="Underline, accent" variant="ds" />
             <TagTabs
               tabs={(["positive", "negative", "general"] as const).map((id) => ({ id, label: id[0].toUpperCase() + id.slice(1), count: 0 }))}
@@ -230,7 +177,7 @@ export function DesignSystemSection() {
             />
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Entry row" aside="Collapsible details" variant="ds" />
             <details className={ENTRY_ROW} open>
               <summary className={ENTRY_SUMMARY}>
@@ -247,36 +194,36 @@ export function DesignSystemSection() {
             </details>
           </section>
 
-          <section className="flex flex-col gap-stack">
+          <section className="flex flex-col gap-3">
             <SectionHead title="Memorable days" aside="Calendar · list · emoji" variant="ds" />
-            <div className="flex flex-col gap-stack items-stretch">
+            <div className="flex flex-col gap-3 items-stretch">
               <div className="flex items-center">
-                <div className="flex gap-inline items-center">
+                <div className="flex gap-2 items-center">
                   <Button className="flex-shrink-0 tracking-[0.01em]">Prev</Button>
                   <Button className="tracking-[0.01em] min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap" aria-label="Go to current month (demo)">May 2026</Button>
                   <Button className="flex-shrink-0 tracking-[0.01em]">Next</Button>
                 </div>
               </div>
               <Button variant="primary">Add new</Button>
-              <div className="flex items-center gap-inline mb-inline">
+              <div className="flex items-center gap-2 mb-2">
                 {DS_MEMORABLE_WEEKDAY_LABELS.map((d) => (
                   <span key={d} className="flex-1 text-center text-muted text-xs font-bold uppercase">{d}</span>
                 ))}
               </div>
               <div className="max-w-[480px] w-full">
-                <div className="grid grid-cols-[repeat(7,minmax(0,1fr))] gap-inline">
+                <div className="grid grid-cols-[repeat(7,minmax(0,1fr))] gap-2">
                   {[
                     { n: 27, mod: "opacity-[0.48]" },
                     { n: 28, mod: "shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_28%,transparent)]" },
                     { n: 29, marker: "Team lunch" },
                     { n: 30 }, { n: 1 }, { n: 2 }, { n: 3 },
                   ].map((cell) => (
-                    <div key={cell.n} className={`${MEMO_DAY_CELL} !min-h-[72px] !p-inline ${cell.mod ?? ""}`}>
+                    <div key={cell.n} className={`${MEMO_DAY_CELL} !min-h-[72px] !p-2 ${cell.mod ?? ""}`}>
                       <span className="flex items-center justify-between">
                         <button type="button" className={DAY_NUMBER} tabIndex={-1} onClick={(e) => e.preventDefault()}>{cell.n}</button>
                       </span>
                       {cell.marker ? (
-                        <span className="flex flex-col gap-inline">
+                        <span className="flex flex-col gap-2">
                           <span className="text-xs leading-snug text-muted whitespace-nowrap overflow-hidden text-ellipsis">{cell.marker}</span>
                         </span>
                       ) : null}
@@ -286,15 +233,15 @@ export function DesignSystemSection() {
               </div>
               <button type="button" className={MEMO_LIST_ITEM}>
                 <span className="text-[22px] leading-none">🎂</span>
-                <span className="flex-1 flex flex-col gap-tight items-start">
-                  <span className="w-full flex items-baseline justify-between gap-stack">
+                <span className="flex-1 flex flex-col gap-1 items-start">
+                  <span className="w-full flex items-baseline justify-between gap-3">
                     <strong className="text-base min-w-0 text-text">Sample day</strong>
                     <span className="text-muted text-control flex-shrink-0 text-right">05-15</span>
                   </span>
                   <span className="text-micro text-muted-soft">yearly</span>
                 </span>
               </button>
-              <div className="flex items-center gap-inline flex-wrap">
+              <div className="flex items-center gap-2 flex-wrap">
                 <button type="button" className={EMOJI_TRIGGER} aria-label="Emoji picker trigger demo">
                   <span className="text-[32px] leading-none" aria-hidden>✨</span>
                 </button>

--- a/frontend/src/app/DesignSystemSection.tsx
+++ b/frontend/src/app/DesignSystemSection.tsx
@@ -28,8 +28,7 @@ const DESIGN_COLOR_TOKENS: { name: string; varName: string; role: string }[] = [
   { name: "Text", varName: "--text", role: "Primary text" },
   { name: "Muted", varName: "--muted", role: "Secondary text" },
   { name: "Muted soft", varName: "--muted-soft", role: "Tertiary text" },
-  { name: "Border", varName: "--border", role: "Dividers" },
-  { name: "Border soft", varName: "--border-soft", role: "Hairlines" },
+  { name: "Border", varName: "--border", role: "Dividers, hairlines" },
   { name: "Accent", varName: "--accent", role: "Primary action" },
   { name: "Success", varName: "--success", role: "Positive state" },
   { name: "Warning", varName: "--warning", role: "Mid state" },
@@ -52,13 +51,13 @@ export function DesignSystemSection() {
 
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Design System</h1>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Design System</h1>
       <p className="text-muted text-control mt-2 mb-5 max-w-[72ch] [&_code]:px-[6px] [&_code]:py-[1px] [&_code]:rounded-[6px] [&_code]:bg-card-soft [&_code]:text-text">
         Living reference for tokens, primitives, and patterns used across Diary, Pain, therapy forms, and Memorable days.
         Examples use the same classes as production &mdash; edit <code>styles.css</code> and this page tracks it.
       </p>
 
-      <div className="grid gap-8 mt-8 items-start min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12">
+      <div className="grid gap-8 mt-8 items-start wide:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] wide:gap-12">
         <div className="block min-w-0 [&>section+section]:mt-3">
           <EntriesHeading className="mt-0 mb-5">Foundations</EntriesHeading>
 
@@ -119,7 +118,7 @@ export function DesignSystemSection() {
           </section>
         </div>
 
-        <div className="block min-w-0 [&>section+section]:mt-3 min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-12">
+        <div className="block min-w-0 [&>section+section]:mt-3 wide:border-l wide:border-border wide:pl-12">
           <EntriesHeading className="mt-0 mb-5">Components</EntriesHeading>
 
           <section className="flex flex-col gap-3">
@@ -232,7 +231,7 @@ export function DesignSystemSection() {
                 </div>
               </div>
               <button type="button" className={MEMO_LIST_ITEM}>
-                <span className="text-[22px] leading-none">🎂</span>
+                <span className="text-title leading-none">🎂</span>
                 <span className="flex-1 flex flex-col gap-1 items-start">
                   <span className="w-full flex items-baseline justify-between gap-3">
                     <strong className="text-base min-w-0 text-text">Sample day</strong>

--- a/frontend/src/app/DesignSystemSection.tsx
+++ b/frontend/src/app/DesignSystemSection.tsx
@@ -116,6 +116,27 @@ export function DesignSystemSection() {
               <PainBadge variant="muted" sm>&mdash;</PainBadge>
             </div>
           </section>
+
+          <section className="flex flex-col gap-3">
+            <SectionHead title="Elevation" aside="Shadows + focus ring" variant="ds" />
+            <ul className="list-none m-0 p-0 flex flex-wrap gap-5">
+              <li className="flex flex-col items-center gap-2 text-micro text-muted">
+                <span className="w-[72px] h-[48px] rounded-md bg-card-strong shadow-[var(--shadow-sm)]" />
+                <code>--shadow-sm</code>
+              </li>
+              <li className="flex flex-col items-center gap-2 text-micro text-muted">
+                <span className="w-[72px] h-[48px] rounded-md bg-card-strong shadow-[var(--shadow)]" />
+                <code>--shadow</code>
+              </li>
+              <li className="flex flex-col items-center gap-2 text-micro text-muted">
+                <span className="w-[72px] h-[48px] rounded-md bg-card-strong shadow-[0_0_0_2px_var(--ring)]" />
+                <code>--ring</code>
+              </li>
+            </ul>
+            <p className="m-0 text-micro text-muted-soft leading-snug [&_code]:text-muted">
+              Keyboard focus uses <code>focus-visible:shadow-[0_0_0_2px_var(--ring)]</code> across buttons, inputs, and pills.
+            </p>
+          </section>
         </div>
 
         <div className="block min-w-0 [&>section+section]:mt-3 wide:border-l wide:border-border wide:pl-12">

--- a/frontend/src/app/DiarySection.tsx
+++ b/frontend/src/app/DiarySection.tsx
@@ -34,7 +34,7 @@ import {
 } from "./entries";
 
 const DATETIME_FIELD =
-  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-inline [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
+  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-2 [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
 
 export function DiarySection({
   diaryForm,
@@ -84,13 +84,13 @@ export function DiarySection({
   } = useDiaryColumnCap(diaryEntries, isLoading);
 
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Diary</h1>
-      <div className="grid gap-page min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-split min-[1100px]:items-start">
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Diary</h1>
+      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
         <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
           <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
-          <form className="mb-inline" onSubmit={diaryForm.handleSubmit(onSubmit)}>
-            <div className="grid gap-stack content-start min-w-0">
+          <form className="mb-2" onSubmit={diaryForm.handleSubmit(onSubmit)}>
+            <div className="grid gap-3 content-start min-w-0">
               <div className="sr-only" aria-hidden="true">
                 <input type="hidden" {...diaryForm.register("moodLevel", { valueAsNumber: true })} />
                 <input type="hidden" {...diaryForm.register("depressionLevel", { valueAsNumber: true })} />
@@ -107,7 +107,7 @@ export function DiarySection({
                   el.showPicker?.();
                 }}
               />
-              <div className="grid gap-inline content-start">
+              <div className="grid gap-2 content-start">
                 <span className={FIELD_LINE_LABEL}>Values</span>
               </div>
               <BarMetric
@@ -144,7 +144,7 @@ export function DiarySection({
                 aria-label="Gratitude"
               />
               {editingDiary ? (
-                <div className="flex gap-inline flex-wrap">
+                <div className="flex gap-2 flex-wrap">
                   <Button type="button" onClick={onCancelEdit}>
                     Cancel edit
                   </Button>
@@ -152,11 +152,11 @@ export function DiarySection({
               ) : null}
             </div>
 
-            <div className="grid gap-block min-w-0 pt-block">
-              <div className="grid gap-stack">
+            <div className="grid gap-5 min-w-0 pt-5">
+              <div className="grid gap-3">
                 <SectionHead title="Emotions" variant="tags" />
                 <TagTabs tabs={moodTabs} active={moodTab} onSelect={setMoodTab} ariaLabel="Mood categories" />
-                <div className="grid gap-stack">
+                <div className="grid gap-3">
                   {moodTab === "positive" ? (
                     <MultiSelectField
                       hideLabel
@@ -192,8 +192,8 @@ export function DiarySection({
                   ) : null}
                 </div>
               </div>
-              <div className="flex justify-end pt-inline">
-                <Button type="submit" variant={diaryMutationState.isSuccess ? "success" : "primary"} className="mb-block">
+              <div className="flex justify-end pt-2">
+                <Button type="submit" variant={diaryMutationState.isSuccess ? "success" : "primary"} className="mb-5">
                   {diaryMutationState.isSuccess ? "✓ Saved" : editingDiary ? "Update entry" : "Save entry"}
                 </Button>
               </div>

--- a/frontend/src/app/DiarySection.tsx
+++ b/frontend/src/app/DiarySection.tsx
@@ -85,10 +85,10 @@ export function DiarySection({
 
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Diary</h1>
-      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
-        <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
-          <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Diary</h1>
+      <div className="grid gap-8 wide:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] wide:gap-12 wide:items-start">
+        <div className="min-w-0 max-wide:border-b max-wide:border-border" ref={leftColRef}>
+          <EntriesHeading className="wide:mt-0">New entry</EntriesHeading>
           <form className="mb-2" onSubmit={diaryForm.handleSubmit(onSubmit)}>
             <div className="grid gap-3 content-start min-w-0">
               <div className="sr-only" aria-hidden="true">

--- a/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/src/app/ErrorBoundary.tsx
@@ -8,8 +8,8 @@ function logError(error: unknown, info: { componentStack?: string | null }, cont
 
 function RootFallback({ resetErrorBoundary }: FallbackProps) {
   return (
-    <main className="grid place-items-center min-h-screen p-0 max-[720px]:p-stack">
-      <section className="w-[min(560px,94vw)] bg-card border border-border rounded-lg p-stack shadow-[var(--shadow)] grid gap-stack" role="alert">
+    <main className="grid place-items-center min-h-screen p-0 max-mobile:p-3">
+      <section className="w-[min(560px,94vw)] bg-card border border-border rounded-lg p-3 shadow-[var(--shadow)] grid gap-3" role="alert">
         <h1>Something went wrong</h1>
         <p className="text-muted text-control">
           The app hit an unexpected error and couldn&apos;t continue. Reloading
@@ -28,7 +28,7 @@ function RootFallback({ resetErrorBoundary }: FallbackProps) {
 
 function SectionFallback({ resetErrorBoundary }: FallbackProps) {
   return (
-    <div className="grid gap-inline my-stack" role="alert">
+    <div className="grid gap-2 my-3" role="alert">
       <p className="text-control font-semibold text-text m-0">This section ran into a problem</p>
       <p className="max-w-[60ch] text-control text-muted leading-normal m-0">
         Something went wrong while loading this view. The rest of the app is

--- a/frontend/src/app/LoginScreen.tsx
+++ b/frontend/src/app/LoginScreen.tsx
@@ -4,7 +4,7 @@ import { Button } from "../components/ui/Button";
 
 const LOGIN_LABEL = "grid gap-1 content-start text-muted text-control";
 const LOGIN_INPUT =
-  "w-full max-w-full p-3 bg-card-strong text-text border border-border rounded-sm outline-none text-base shadow-[var(--shadow-sm)] transition-[border-color,background] duration-200 ease-[ease] focus:border-accent focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] focus-visible:outline-none focus-visible:border-accent focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_38%,transparent),var(--shadow-sm)]";
+  "w-full max-w-full p-3 bg-card-strong text-text border border-border rounded-sm outline-none text-base shadow-[var(--shadow-sm)] transition-[border-color,background] duration-200 ease-[ease] focus:border-accent focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] focus-visible:outline-none focus-visible:border-accent focus-visible:shadow-[0_0_0_2px_var(--ring),var(--shadow-sm)]";
 
 type LoginScreenProps = {
   loginForm: UseFormReturn<{ email: string; password: string }>;

--- a/frontend/src/app/LoginScreen.tsx
+++ b/frontend/src/app/LoginScreen.tsx
@@ -2,9 +2,9 @@ import type { UseFormReturn } from "react-hook-form";
 import type { UseMutationResult } from "@tanstack/react-query";
 import { Button } from "../components/ui/Button";
 
-const LOGIN_LABEL = "grid gap-tight content-start text-muted text-control";
+const LOGIN_LABEL = "grid gap-1 content-start text-muted text-control";
 const LOGIN_INPUT =
-  "w-full max-w-full p-stack bg-card-strong text-text border border-border rounded-sm outline-none text-base shadow-[var(--shadow-sm)] transition-[border-color,background] duration-200 ease-[ease] focus:border-accent focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] focus-visible:outline-none focus-visible:border-accent focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_38%,transparent),var(--shadow-sm)]";
+  "w-full max-w-full p-3 bg-card-strong text-text border border-border rounded-sm outline-none text-base shadow-[var(--shadow-sm)] transition-[border-color,background] duration-200 ease-[ease] focus:border-accent focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] focus-visible:outline-none focus-visible:border-accent focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_38%,transparent),var(--shadow-sm)]";
 
 type LoginScreenProps = {
   loginForm: UseFormReturn<{ email: string; password: string }>;
@@ -13,11 +13,11 @@ type LoginScreenProps = {
 
 export function LoginScreen({ loginForm, loginMutation }: LoginScreenProps) {
   return (
-    <main className="grid place-items-center min-h-screen p-0 max-[720px]:p-stack">
-      <section className="w-[min(560px,94vw)] bg-card border border-border rounded-lg p-stack shadow-[var(--shadow)]">
+    <main className="grid place-items-center min-h-screen p-0 max-mobile:p-3">
+      <section className="w-[min(560px,94vw)] bg-card border border-border rounded-lg p-3 shadow-[var(--shadow)]">
         <h1>Health</h1>
         <p>Sign in to access your private health workspace.</p>
-        <form noValidate onSubmit={loginForm.handleSubmit((values) => loginMutation.mutate(values))} className="grid gap-stack">
+        <form noValidate onSubmit={loginForm.handleSubmit((values) => loginMutation.mutate(values))} className="grid gap-3">
           <label className={LOGIN_LABEL}>
             Email
             <input

--- a/frontend/src/app/McpAccessSection.tsx
+++ b/frontend/src/app/McpAccessSection.tsx
@@ -8,7 +8,7 @@ import { TAG_TAB_BTN } from "./entries";
 
 const MCP_INTRO = "mt-[6px] mb-0 text-hint leading-normal text-muted";
 const CODE_BLOCK =
-  "m-0 p-stack bg-card-soft text-text border border-[var(--border-soft)] rounded-sm font-medium text-xs font-mono leading-normal overflow-x-auto whitespace-pre";
+  "m-0 p-3 bg-card-soft text-text border border-[var(--border-soft)] rounded-sm font-medium text-xs font-mono leading-normal overflow-x-auto whitespace-pre";
 
 const EXPIRY_OPTIONS: { value: ExpiryChoice; label: string }[] = [
   { value: "never", label: "Never" },
@@ -122,7 +122,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
       </p>
 
       {tokens.justCreated ? (
-        <div className="flex flex-col gap-inline mt-[8px] p-stack bg-[color-mix(in_srgb,var(--warning)_10%,var(--card))] border border-[color-mix(in_srgb,var(--warning)_40%,var(--border))] rounded-sm">
+        <div className="flex flex-col gap-2 mt-[8px] p-3 bg-[color-mix(in_srgb,var(--warning)_10%,var(--card))] border border-[color-mix(in_srgb,var(--warning)_40%,var(--border))] rounded-sm">
           <InlineFeedback
             message={{
               tone: "warning",
@@ -130,7 +130,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
             }}
           />
           <pre className={CODE_BLOCK}>{tokens.justCreated.plaintext}</pre>
-          <div className="flex gap-stack items-center flex-wrap mt-stack">
+          <div className="flex gap-3 items-center flex-wrap mt-3">
             <Button type="button" variant="primary" onClick={() => void handleCopy(tokens.justCreated!.plaintext)}>
               Copy token
             </Button>
@@ -158,7 +158,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
       ) : (
         <ul className="list-none p-0 mt-[4px] mb-0 flex flex-col">
           {tokens.tokens.map((t) => (
-            <li key={t.id} className="flex items-center justify-between gap-stack px-[2px] py-[10px] border-b border-[var(--border-soft)] last:border-b-0">
+            <li key={t.id} className="flex items-center justify-between gap-3 px-[2px] py-[10px] border-b border-[var(--border-soft)] last:border-b-0">
               <div className="min-w-0 flex-1 flex flex-col gap-[2px]">
                 <div className="text-sm font-semibold font-body text-text overflow-hidden text-ellipsis whitespace-nowrap">{t.label || `Token #${t.id}`}</div>
                 <div className="text-xs text-muted tabular-nums">
@@ -189,7 +189,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
             placeholder="e.g. Claude Desktop MacBook"
             maxLength={100}
           />
-          <div className="grid gap-inline content-start">
+          <div className="grid gap-2 content-start">
             <span className={FIELD_LINE_LABEL}>Expiry</span>
             <Select
               ariaLabel="Expiry"
@@ -201,7 +201,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
               options={EXPIRY_OPTIONS}
             />
           </div>
-          <div className="flex justify-end gap-inline pt-[4px]">
+          <div className="flex justify-end gap-2 pt-[4px]">
             <Button type="button" variant="primary" onClick={handleCreate} disabled={tokens.createPending}>
               {tokens.createPending ? "Creating…" : "Create token"}
             </Button>
@@ -211,7 +211,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
           </div>
         </div>
       ) : (
-        <div className="flex justify-end pt-inline">
+        <div className="flex justify-end pt-2">
           <Button type="button" onClick={() => setShowCreateForm(true)}>
             + Create new token
           </Button>
@@ -221,7 +221,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
       <InlineFeedback message={tokens.feedback} />
 
       <SectionHead title="How to connect" />
-      <nav className="flex flex-wrap gap-y-tight gap-x-block mt-[4px]" role="tablist" aria-label="MCP client instructions">
+      <nav className="flex flex-wrap gap-y-1 gap-x-5 mt-[4px]" role="tablist" aria-label="MCP client instructions">
         {(["generic", "claude-desktop", "claude-code", "curl"] as const).map((tab) => (
           <button
             key={tab}
@@ -276,10 +276,10 @@ function McpClientInstructions({
   }
 
   return (
-    <div className="flex flex-col gap-inline mt-[4px]">
+    <div className="flex flex-col gap-2 mt-[4px]">
       <p className={MCP_INTRO}>{description}</p>
       <pre className={CODE_BLOCK}>{snippet}</pre>
-      <div className="flex justify-end pt-inline">
+      <div className="flex justify-end pt-2">
         <Button type="button" onClick={() => onCopy(snippet)}>
           Copy
         </Button>

--- a/frontend/src/app/McpAccessSection.tsx
+++ b/frontend/src/app/McpAccessSection.tsx
@@ -8,7 +8,7 @@ import { TAG_TAB_BTN } from "./entries";
 
 const MCP_INTRO = "mt-[6px] mb-0 text-hint leading-normal text-muted";
 const CODE_BLOCK =
-  "m-0 p-3 bg-card-soft text-text border border-[var(--border-soft)] rounded-sm font-medium text-xs font-mono leading-normal overflow-x-auto whitespace-pre";
+  "m-0 p-3 bg-card-soft text-text border border-border rounded-sm font-medium text-xs font-mono leading-normal overflow-x-auto whitespace-pre";
 
 const EXPIRY_OPTIONS: { value: ExpiryChoice; label: string }[] = [
   { value: "never", label: "Never" },
@@ -158,7 +158,7 @@ export function McpAccessSection({ enabled }: { enabled: boolean }) {
       ) : (
         <ul className="list-none p-0 mt-[4px] mb-0 flex flex-col">
           {tokens.tokens.map((t) => (
-            <li key={t.id} className="flex items-center justify-between gap-3 px-[2px] py-[10px] border-b border-[var(--border-soft)] last:border-b-0">
+            <li key={t.id} className="flex items-center justify-between gap-3 px-[2px] py-[10px] border-b border-border last:border-b-0">
               <div className="min-w-0 flex-1 flex flex-col gap-[2px]">
                 <div className="text-sm font-semibold font-body text-text overflow-hidden text-ellipsis whitespace-nowrap">{t.label || `Token #${t.id}`}</div>
                 <div className="text-xs text-muted tabular-nums">

--- a/frontend/src/app/MedicinePreselectionSection.tsx
+++ b/frontend/src/app/MedicinePreselectionSection.tsx
@@ -56,7 +56,7 @@ export function MedicinePreselectionSection({ enabled }: { enabled: boolean }) {
 
   return (
     <div className="grid gap-3">
-      <SectionHead title="Medicine preselection" ruled />
+      <SectionHead title="Medicine preselection" />
       <p className="text-muted text-control">Choose which medicines start already selected when you log a new pain entry.</p>
       {optionsQuery.isLoading ? (
         <p className="text-muted text-control">Loading…</p>

--- a/frontend/src/app/MedicinePreselectionSection.tsx
+++ b/frontend/src/app/MedicinePreselectionSection.tsx
@@ -55,7 +55,7 @@ export function MedicinePreselectionSection({ enabled }: { enabled: boolean }) {
   };
 
   return (
-    <div className="grid gap-stack">
+    <div className="grid gap-3">
       <SectionHead title="Medicine preselection" ruled />
       <p className="text-muted text-control">Choose which medicines start already selected when you log a new pain entry.</p>
       {optionsQuery.isLoading ? (

--- a/frontend/src/app/PainSection.tsx
+++ b/frontend/src/app/PainSection.tsx
@@ -108,10 +108,10 @@ export function PainSection({
 
   return (
     <section className="@container p-2">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Pain</h1>
-      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
-        <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
-          <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Pain</h1>
+      <div className="grid gap-8 wide:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] wide:gap-12 wide:items-start">
+        <div className="min-w-0 max-wide:border-b max-wide:border-border" ref={leftColRef}>
+          <EntriesHeading className="wide:mt-0">New entry</EntriesHeading>
           <form className="mb-2" onSubmit={painForm.handleSubmit(onSubmit)}>
             <div className="grid gap-3 content-start min-w-0">
               <div className="sr-only" aria-hidden="true">

--- a/frontend/src/app/PainSection.tsx
+++ b/frontend/src/app/PainSection.tsx
@@ -35,7 +35,7 @@ import {
 } from "./entries";
 
 const DATETIME_FIELD =
-  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-inline [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
+  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-2 [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
 
 const PAIN_TABS: { id: PainFieldKey; label: string }[] = [
   { id: "area", label: "Area" },
@@ -107,13 +107,13 @@ export function PainSection({
   ];
 
   return (
-    <section className="@container p-inline">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Pain</h1>
-      <div className="grid gap-page min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-split min-[1100px]:items-start">
+    <section className="@container p-2">
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Pain</h1>
+      <div className="grid gap-8 min-[1100px]:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] min-[1100px]:gap-12 min-[1100px]:items-start">
         <div className="min-w-0 max-[1099px]:border-b max-[1099px]:border-[var(--border-soft)]" ref={leftColRef}>
           <EntriesHeading className="min-[1100px]:mt-0">New entry</EntriesHeading>
-          <form className="mb-inline" onSubmit={painForm.handleSubmit(onSubmit)}>
-            <div className="grid gap-stack content-start min-w-0">
+          <form className="mb-2" onSubmit={painForm.handleSubmit(onSubmit)}>
+            <div className="grid gap-3 content-start min-w-0">
               <div className="sr-only" aria-hidden="true">
                 <input type="hidden" {...painForm.register("painLevel", { valueAsNumber: true })} />
                 <input type="hidden" {...painForm.register("fatigueLevel", { valueAsNumber: true })} />
@@ -130,7 +130,7 @@ export function PainSection({
                   el.showPicker?.();
                 }}
               />
-              <div className="grid gap-inline content-start">
+              <div className="grid gap-2 content-start">
                 <span className={FIELD_LINE_LABEL}>Values</span>
               </div>
               <BarMetric
@@ -153,7 +153,7 @@ export function PainSection({
                 aria-label="Note"
               />
               {editingPain ? (
-                <div className="flex gap-inline flex-wrap">
+                <div className="flex gap-2 flex-wrap">
                   <Button type="button" onClick={onCancelEdit}>
                     Cancel edit
                   </Button>
@@ -161,8 +161,8 @@ export function PainSection({
               ) : null}
             </div>
 
-            <div className="grid gap-block min-w-0 pt-block">
-              <div className="grid gap-stack">
+            <div className="grid gap-5 min-w-0 pt-5">
+              <div className="grid gap-3">
                 <SectionHead title="Factors" variant="tags" />
                 <TagTabs
                   tabs={PAIN_TABS.map((t) => ({ id: t.id, label: t.label, count: painTabCounts[t.id] }))}
@@ -170,7 +170,7 @@ export function PainSection({
                   onSelect={setPainTab}
                   ariaLabel="Pain categories"
                 />
-                <div className="grid gap-stack">
+                <div className="grid gap-3">
                   <MultiSelectField
                     hideLabel
                     label={tabLabel}
@@ -181,8 +181,8 @@ export function PainSection({
                   />
                 </div>
               </div>
-              <div className="flex justify-end pt-inline">
-                <Button type="submit" variant={painMutationState.isSuccess ? "success" : "primary"} className="mb-block">
+              <div className="flex justify-end pt-2">
+                <Button type="submit" variant={painMutationState.isSuccess ? "success" : "primary"} className="mb-5">
                   {painMutationState.isSuccess ? "✓ Saved" : editingPain ? "Update entry" : "Save entry"}
                 </Button>
               </div>

--- a/frontend/src/app/SettingsPanel.tsx
+++ b/frontend/src/app/SettingsPanel.tsx
@@ -45,9 +45,9 @@ function BirthdayBlock({
   };
 
   return (
-    <div className="grid gap-stack">
+    <div className="grid gap-3">
       <SectionHead title="Birthday" ruled />
-      <label className="grid gap-inline content-start">
+      <label className="grid gap-2 content-start">
         <DateInput value={value} onChange={handleChange} ariaLabel="Birthday" />
       </label>
       <p className="text-muted text-control">Why: this becomes a locked birthday item in Memorable days.{birthdayPending ? " Saving…" : ""}</p>
@@ -58,9 +58,9 @@ function BirthdayBlock({
 function ThemeBlock() {
   const { theme, setTheme } = useTheme();
   return (
-    <div className="grid gap-stack">
+    <div className="grid gap-3">
       <SectionHead title="Theme" ruled />
-      <div className="flex flex-wrap gap-block" role="group" aria-label="Theme">
+      <div className="flex flex-wrap gap-5" role="group" aria-label="Theme">
         {THEMES.map((t) => {
           const selected = t.id === theme;
           const dotShadow = selected
@@ -102,16 +102,16 @@ function ThemeBlock() {
 
 function AccountBlock({ auth }: Pick<SettingsSectionProps, "auth">) {
   return (
-    <div className="flex flex-col gap-inline">
+    <div className="flex flex-col gap-2">
       <form
-        className="grid gap-stack"
+        className="grid gap-3"
         onFocus={auth.clearPasswordStatus}
         onSubmit={auth.changePasswordForm.handleSubmit((v) => auth.changePasswordMutation.mutate(v))}
       >
         <FieldLine label="Current password" type="password" autoComplete="current-password" {...auth.changePasswordForm.register("currentPassword")} />
         <FieldLine label="New password" type="password" autoComplete="new-password" {...auth.changePasswordForm.register("newPassword")} />
         <FieldLine label="Confirm" type="password" autoComplete="new-password" {...auth.changePasswordForm.register("confirmPassword")} />
-        <div className="flex justify-end pt-inline">
+        <div className="flex justify-end pt-2">
           <Button type="submit" variant="primary" className="mt-[12px]" disabled={auth.changePasswordMutation.isPending}>
             Change password
           </Button>
@@ -124,7 +124,7 @@ function AccountBlock({ auth }: Pick<SettingsSectionProps, "auth">) {
           }
         />
       </form>
-      <div className="flex justify-end pt-inline">
+      <div className="flex justify-end pt-2">
         <Button type="button" onClick={() => auth.logoutMutation.mutate()} disabled={auth.logoutMutation.isPending}>
           Log out
         </Button>
@@ -140,13 +140,13 @@ function BackupBlock({
   onImportXlsx,
 }: Pick<SettingsSectionProps, "onExportJson" | "onImportJson" | "onExportXlsx" | "onImportXlsx">) {
   return (
-    <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-inline">
-      <div className="flex items-center justify-between gap-block px-[14px] py-[12px] rounded-md bg-card-strong max-sm:flex-col max-sm:items-stretch">
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-2">
+      <div className="flex items-center justify-between gap-5 px-[14px] py-[12px] rounded-md bg-card-strong max-sm:flex-col max-sm:items-stretch">
         <div className="flex flex-col gap-[2px] min-w-0">
           <span className="text-sm font-bold text-text">JSON</span>
           <span className="text-xs text-muted">Full database</span>
         </div>
-        <div className="flex gap-inline flex-shrink-0 max-sm:justify-end">
+        <div className="flex gap-2 flex-shrink-0 max-sm:justify-end">
           <Button type="button" size="sm" onClick={onExportJson}>Export</Button>
           <label className={`${buttonClass("default", "sm")} relative overflow-hidden cursor-pointer`}>
             Import
@@ -163,12 +163,12 @@ function BackupBlock({
           </label>
         </div>
       </div>
-      <div className="flex items-center justify-between gap-block px-[14px] py-[12px] rounded-md bg-card-strong max-sm:flex-col max-sm:items-stretch">
+      <div className="flex items-center justify-between gap-5 px-[14px] py-[12px] rounded-md bg-card-strong max-sm:flex-col max-sm:items-stretch">
         <div className="flex flex-col gap-[2px] min-w-0">
           <span className="text-sm font-bold text-text">XLSX</span>
           <span className="text-xs text-muted">Spreadsheet</span>
         </div>
-        <div className="flex gap-inline flex-shrink-0 max-sm:justify-end">
+        <div className="flex gap-2 flex-shrink-0 max-sm:justify-end">
           <Button type="button" size="sm" onClick={onExportXlsx}>Export</Button>
           <label className={`${buttonClass("default", "sm")} relative overflow-hidden cursor-pointer`}>
             Import
@@ -198,19 +198,19 @@ function DangerBlock({
   onPurgeCancel,
 }: Pick<SettingsSectionProps, "purgeConfirmArmed" | "purgePending" | "purgeError" | "onPurgeArm" | "onPurgeConfirm" | "onPurgeCancel">) {
   return (
-    <div className="flex flex-col gap-stack">
-      <p className="m-0 px-stack py-inline bg-[color-mix(in_srgb,var(--danger)_7%,var(--card))] border-l-2 border-[color-mix(in_srgb,var(--danger)_55%,transparent)] rounded-sm text-muted text-hint leading-normal">
+    <div className="flex flex-col gap-3">
+      <p className="m-0 px-3 py-2 bg-[color-mix(in_srgb,var(--danger)_7%,var(--card))] border-l-2 border-[color-mix(in_srgb,var(--danger)_55%,transparent)] rounded-sm text-muted text-hint leading-normal">
         Permanently deletes all diary entries, pain logs, CBT/DBT records, and stored preferences for this account. This cannot be undone.
       </p>
       {purgeConfirmArmed ? (
-        <div className="mt-stack p-stack border border-[color-mix(in_srgb,var(--danger)_40%,var(--border))] rounded-md bg-[color-mix(in_srgb,var(--danger)_8%,var(--card))] grid gap-stack" role="group" aria-label="Confirm purge all data">
+        <div className="mt-3 p-3 border border-[color-mix(in_srgb,var(--danger)_40%,var(--border))] rounded-md bg-[color-mix(in_srgb,var(--danger)_8%,var(--card))] grid gap-3" role="group" aria-label="Confirm purge all data">
           <InlineFeedback
             message={{
               tone: "warning",
               text: "This permanently deletes all diary, pain, and preference data for this account.",
             }}
           />
-          <div className="flex gap-stack items-center flex-wrap [grid-column:1/-1]">
+          <div className="flex gap-3 items-center flex-wrap [grid-column:1/-1]">
             <Button type="button" variant="danger" onClick={onPurgeConfirm} disabled={purgePending}>
               {purgePending ? "Purging..." : "Confirm purge all data"}
             </Button>
@@ -220,7 +220,7 @@ function DangerBlock({
           </div>
         </div>
       ) : (
-        <div className="flex justify-end pt-inline">
+        <div className="flex justify-end pt-2">
           <Button type="button" variant="danger" onClick={onPurgeArm}>
             Purge all data
           </Button>
@@ -235,7 +235,7 @@ function AccountIdentity({ auth }: Pick<SettingsSectionProps, "auth">) {
   const email = auth.user?.email ?? "—";
   const name = auth.user?.name?.trim();
   return (
-    <div className="flex items-center gap-stack p-stack bg-card border border-[var(--border-soft)] rounded-sm">
+    <div className="flex items-center gap-3 p-3 bg-card border border-[var(--border-soft)] rounded-sm">
       <div className="w-[36px] h-[36px] rounded-full grid place-items-center text-sm font-bold font-body text-accent bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] border border-[color-mix(in_srgb,var(--accent)_35%,transparent)]" aria-hidden="true">
         {(name || email).slice(0, 1).toUpperCase()}
       </div>
@@ -260,9 +260,9 @@ const settingsTabs: { id: SettingsTab; label: string; danger?: boolean }[] = [
 export function SettingsPanel(props: SettingsSectionProps) {
   const [tab, setTab] = useState<SettingsTab>("account");
   return (
-    <div className="flex flex-col gap-block">
+    <div className="flex flex-col gap-5">
       <AccountIdentity auth={props.auth} />
-      <nav className="flex flex-wrap gap-y-tight gap-x-block mb-[-10px] pb-inline" aria-label="Settings sections">
+      <nav className="flex flex-wrap gap-y-1 gap-x-5 mb-[-10px] pb-2" aria-label="Settings sections">
         {settingsTabs.map((t) => {
           const isActive = tab === t.id;
           const color = t.danger ? "text-danger" : isActive ? "text-text" : "text-muted hover:text-text";
@@ -279,10 +279,10 @@ export function SettingsPanel(props: SettingsSectionProps) {
           );
         })}
       </nav>
-      <div className="pt-[4px] flex flex-col gap-stack">
+      <div className="pt-[4px] flex flex-col gap-3">
         {tab === "account" ? <AccountBlock auth={props.auth} /> : null}
         {tab === "preferences" ? (
-          <div className="grid gap-stack">
+          <div className="grid gap-3">
             <ThemeBlock />
             <BirthdayBlock
               birthday={props.birthday}

--- a/frontend/src/app/SettingsPanel.tsx
+++ b/frontend/src/app/SettingsPanel.tsx
@@ -235,7 +235,7 @@ function AccountIdentity({ auth }: Pick<SettingsSectionProps, "auth">) {
   const email = auth.user?.email ?? "—";
   const name = auth.user?.name?.trim();
   return (
-    <div className="flex items-center gap-3 p-3 bg-card border border-[var(--border-soft)] rounded-sm">
+    <div className="flex items-center gap-3 p-3 bg-card border border-border rounded-sm">
       <div className="w-[36px] h-[36px] rounded-full grid place-items-center text-sm font-bold font-body text-accent bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] border border-[color-mix(in_srgb,var(--accent)_35%,transparent)]" aria-hidden="true">
         {(name || email).slice(0, 1).toUpperCase()}
       </div>

--- a/frontend/src/app/SettingsPanel.tsx
+++ b/frontend/src/app/SettingsPanel.tsx
@@ -46,7 +46,7 @@ function BirthdayBlock({
 
   return (
     <div className="grid gap-3">
-      <SectionHead title="Birthday" ruled />
+      <SectionHead title="Birthday" />
       <label className="grid gap-2 content-start">
         <DateInput value={value} onChange={handleChange} ariaLabel="Birthday" />
       </label>
@@ -59,7 +59,7 @@ function ThemeBlock() {
   const { theme, setTheme } = useTheme();
   return (
     <div className="grid gap-3">
-      <SectionHead title="Theme" ruled />
+      <SectionHead title="Theme" />
       <div className="flex flex-wrap gap-5" role="group" aria-label="Theme">
         {THEMES.map((t) => {
           const selected = t.id === theme;

--- a/frontend/src/app/SettingsPanel.tsx
+++ b/frontend/src/app/SettingsPanel.tsx
@@ -65,7 +65,7 @@ function ThemeBlock() {
           const selected = t.id === theme;
           const dotShadow = selected
             ? "shadow-[0_0_0_2px_var(--accent)]"
-            : "shadow-[var(--shadow-sm)] group-hover/sw:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_40%,transparent)]";
+            : "shadow-[var(--shadow-sm)] group-hover/sw:shadow-[0_0_0_2px_var(--ring)]";
           return (
             <button
               key={t.id}

--- a/frontend/src/app/SettingsSection.tsx
+++ b/frontend/src/app/SettingsSection.tsx
@@ -51,7 +51,7 @@ export function SettingsSection({
   };
   return (
     <section className="@container p-0">
-      <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Settings</h1>
+      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Settings</h1>
       <SettingsPanel {...variantProps} />
     </section>
   );

--- a/frontend/src/app/SettingsSection.tsx
+++ b/frontend/src/app/SettingsSection.tsx
@@ -51,7 +51,7 @@ export function SettingsSection({
   };
   return (
     <section className="@container p-0">
-      <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Settings</h1>
+      <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Settings</h1>
       <SettingsPanel {...variantProps} />
     </section>
   );

--- a/frontend/src/app/Sidebar.tsx
+++ b/frontend/src/app/Sidebar.tsx
@@ -3,9 +3,9 @@ import { navLabels, type NavItem } from "./core";
 // .sidebar / .sidebar-close-btn / .mobile-menu-btn keep their class names: the
 // shell's focus-trap + swipe handlers query them. Styling moves to utilities;
 // collapse/mobile state is driven by props (desktop collapse gated behind
-// min-[721px], the mobile drawer behind max-[720px]).
+// the mobile: breakpoint, the mobile drawer behind max-mobile:).
 export const NAV_ITEM =
-  "flex items-center gap-stack w-full p-stack border border-transparent rounded-sm font-[inherit] text-sm font-semibold cursor-pointer transition-all whitespace-nowrap overflow-hidden shadow-none [&>svg]:flex-shrink-0 [&>svg]:w-5 [&>svg]:h-5 max-[720px]:p-[14px_12px] max-[720px]:text-base max-[720px]:[&>svg]:w-[22px] max-[720px]:[&>svg]:h-[22px]";
+  "flex items-center gap-3 w-full p-3 border border-transparent rounded-sm font-[inherit] text-sm font-semibold cursor-pointer transition-all whitespace-nowrap overflow-hidden shadow-none [&>svg]:flex-shrink-0 [&>svg]:w-5 [&>svg]:h-5 max-mobile:p-[14px_12px] max-mobile:text-base max-mobile:[&>svg]:w-[22px] max-mobile:[&>svg]:h-[22px]";
 export const NAV_ITEM_IDLE = "text-muted bg-transparent hover:text-text hover:bg-card-strong";
 export const NAV_ITEM_ACTIVE = "text-accent bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]";
 const NAV_ITEM_SOFT_IDLE = "text-muted bg-card-soft hover:text-text hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
@@ -59,24 +59,24 @@ export function Sidebar({ nav, onNav, collapsed, onToggle, onCloseMobile, mobile
 
   return (
     <aside
-      className={`sidebar sticky top-0 h-screen flex flex-col bg-bg border-r border-border px-inline py-stack gap-inline z-10 max-[720px]:fixed max-[720px]:inset-0 max-[720px]:w-full max-[720px]:h-[100dvh] max-[720px]:p-[14px_18px] max-[720px]:z-[100] max-[720px]:transition-transform max-[720px]:duration-[250ms] max-[720px]:ease-[ease] ${mobileOpen ? "max-[720px]:[transform:translateX(0)]" : "max-[720px]:[transform:translateX(-100%)]"}`}
+      className={`sidebar sticky top-0 h-screen flex flex-col bg-bg border-r border-border px-2 py-3 gap-2 z-10 max-mobile:fixed max-mobile:inset-0 max-mobile:w-full max-mobile:h-[100dvh] max-mobile:p-[14px_18px] max-mobile:z-[100] max-mobile:transition-transform max-mobile:duration-[250ms] max-mobile:ease-[ease] ${mobileOpen ? "max-mobile:[transform:translateX(0)]" : "max-mobile:[transform:translateX(-100%)]"}`}
       aria-label="Main navigation"
       {...(mobileOpen ? { role: "dialog", "aria-modal": true } : {})}
     >
-      <div className={`flex items-center gap-stack pt-tight px-inline pb-stack border-b border-border mb-inline min-h-[48px] overflow-hidden ${collapsed ? "min-[721px]:justify-center min-[721px]:gap-0 min-[721px]:px-0" : ""}`}>
-        <svg className={`flex-shrink-0 transition-all duration-200 ${collapsed ? "min-[721px]:w-0 min-[721px]:opacity-0 min-[721px]:overflow-hidden" : ""}`} viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <div className={`flex items-center gap-3 pt-1 px-2 pb-3 border-b border-border mb-2 min-h-[48px] overflow-hidden ${collapsed ? "mobile:justify-center mobile:gap-0 mobile:px-0" : ""}`}>
+        <svg className={`flex-shrink-0 transition-all duration-200 ${collapsed ? "mobile:w-0 mobile:opacity-0 mobile:overflow-hidden" : ""}`} viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="var(--accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
         </svg>
-        <span className={`text-xl font-bold tracking-tight whitespace-nowrap flex-1 min-w-0 overflow-hidden opacity-100 transition-opacity duration-200 ${collapsed ? "min-[721px]:opacity-0 min-[721px]:flex-[0]" : ""}`}>Health</span>
-        <button className="flex-shrink-0 flex items-center justify-center w-8 h-8 p-0 border-0 rounded-[8px] bg-transparent text-muted cursor-pointer transition-all shadow-none hover:text-text [&>svg]:w-5 [&>svg]:h-5 max-[720px]:hidden" onClick={onToggle} aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+        <span className={`text-xl font-bold tracking-tight whitespace-nowrap flex-1 min-w-0 overflow-hidden opacity-100 transition-opacity duration-200 ${collapsed ? "mobile:opacity-0 mobile:flex-[0]" : ""}`}>Health</span>
+        <button className="flex-shrink-0 flex items-center justify-center w-8 h-8 p-0 border-0 rounded-[8px] bg-transparent text-muted cursor-pointer transition-all shadow-none hover:text-text [&>svg]:w-5 [&>svg]:h-5 max-mobile:hidden" onClick={onToggle} aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" /></svg>
         </button>
-        <button className="sidebar-close-btn hidden max-[720px]:flex items-center justify-center flex-shrink-0 w-9 h-9 p-0 border-0 rounded-[8px] bg-transparent text-muted cursor-pointer shadow-none hover:text-text [&>svg]:w-5 [&>svg]:h-5" onClick={onCloseMobile} aria-label="Close menu">
+        <button className="sidebar-close-btn hidden max-mobile:flex items-center justify-center flex-shrink-0 w-9 h-9 p-0 border-0 rounded-[8px] bg-transparent text-muted cursor-pointer shadow-none hover:text-text [&>svg]:w-5 [&>svg]:h-5" onClick={onCloseMobile} aria-label="Close menu">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
 
-      <nav className="flex flex-col gap-tight flex-1 min-h-0" aria-label="Sections">
+      <nav className="flex flex-col gap-1 flex-1 min-h-0" aria-label="Sections">
         {items.map((item) => (
           <button
             key={item}
@@ -85,12 +85,12 @@ export function Sidebar({ nav, onNav, collapsed, onToggle, onCloseMobile, mobile
             title={collapsed ? navLabels[item] : undefined}
           >
             {navIcons[item]}
-            <span className={`${NAV_LABEL} ${collapsed ? "min-[721px]:opacity-0 min-[721px]:w-0" : ""}`}>{navLabels[item]}</span>
+            <span className={`${NAV_LABEL} ${collapsed ? "mobile:opacity-0 mobile:w-0" : ""}`}>{navLabels[item]}</span>
           </button>
         ))}
       </nav>
 
-      <div className="flex-shrink-0 pt-block mt-inline border-t border-border">
+      <div className="flex-shrink-0 pt-5 mt-2 border-t border-border">
         <button
           type="button"
           className={`${NAV_ITEM} ${nav === dsItem ? NAV_ITEM_ACTIVE : NAV_ITEM_SOFT_IDLE}`}
@@ -98,7 +98,7 @@ export function Sidebar({ nav, onNav, collapsed, onToggle, onCloseMobile, mobile
           title={collapsed ? navLabels[dsItem] : undefined}
         >
           {navIcons[dsItem]}
-          <span className={`${NAV_LABEL} ${collapsed ? "min-[721px]:opacity-0 min-[721px]:w-0" : ""}`}>{navLabels[dsItem]}</span>
+          <span className={`${NAV_LABEL} ${collapsed ? "mobile:opacity-0 mobile:w-0" : ""}`}>{navLabels[dsItem]}</span>
         </button>
       </div>
     </aside>

--- a/frontend/src/app/entries.tsx
+++ b/frontend/src/app/entries.tsx
@@ -6,7 +6,7 @@ import { Button } from "../components/ui/Button";
 // + class constants the screens compose, rather than one rigid component.
 
 export const ENTRY_ROW =
-  "group/row border-0 border-b border-[var(--border-soft)] rounded-none m-0 overflow-hidden bg-transparent transition-[background] duration-150 ease-[ease]";
+  "group/row border-0 border-b border-border rounded-none m-0 overflow-hidden bg-transparent transition-[background] duration-150 ease-[ease]";
 export const ENTRY_SUMMARY =
   "group/sum list-none grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-3 px-[2px] py-3 cursor-pointer border-0 rounded-none shadow-none bg-transparent min-h-0 [&::-webkit-details-marker]:hidden";
 export const ENTRY_DATE =
@@ -58,23 +58,23 @@ export function PastEntriesColumn({
   return (
     <div
       ref={colRef}
-      className="min-w-0 min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-12 min-[1100px]:flex min-[1100px]:flex-col min-[1100px]:min-h-[var(--diary-past-col-max-h,0)] min-[1100px]:max-h-[var(--diary-past-col-max-h,none)]"
+      className="min-w-0 wide:border-l wide:border-border wide:pl-12 wide:flex wide:flex-col wide:min-h-[var(--diary-past-col-max-h,0)] wide:max-h-[var(--diary-past-col-max-h,none)]"
     >
       {isLoading && <p className="text-muted text-control">{loadingText}</p>}
-      <EntriesHeading className="min-[1100px]:mt-0">{title}</EntriesHeading>
+      <EntriesHeading className="wide:mt-0">{title}</EntriesHeading>
       {isEmpty ? (
         emptyState
       ) : (
-        <div className="min-[1100px]:flex min-[1100px]:flex-col min-[1100px]:flex-1 min-[1100px]:min-h-0">
+        <div className="wide:flex wide:flex-col wide:flex-1 wide:min-h-0">
           <div
             ref={bodyRef}
-            className="min-[1100px]:flex-1 min-[1100px]:min-h-0 min-[1100px]:overflow-hidden min-[1100px]:[mask-image:linear-gradient(to_bottom,#000_calc(100%-20px),transparent)]"
+            className="wide:flex-1 wide:min-h-0 wide:overflow-hidden wide:[mask-image:linear-gradient(to_bottom,#000_calc(100%-20px),transparent)]"
           >
             {children}
           </div>
           <div
             aria-hidden={!overflow}
-            className="flex justify-end items-center pt-2 min-[1100px]:flex-shrink-0 min-[1100px]:box-border min-[1100px]:min-h-[calc(8px+40px+20px)]"
+            className="flex justify-end items-center pt-2 wide:flex-shrink-0 wide:box-border wide:min-h-[calc(8px+40px+20px)]"
           >
             {!isLoading && overflow ? <Button className="mb-5">Show more</Button> : null}
           </div>

--- a/frontend/src/app/entries.tsx
+++ b/frontend/src/app/entries.tsx
@@ -8,7 +8,7 @@ import { Button } from "../components/ui/Button";
 export const ENTRY_ROW =
   "group/row border-0 border-b border-[var(--border-soft)] rounded-none m-0 overflow-hidden bg-transparent transition-[background] duration-150 ease-[ease]";
 export const ENTRY_SUMMARY =
-  "group/sum list-none grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-stack px-[2px] py-stack cursor-pointer border-0 rounded-none shadow-none bg-transparent min-h-0 [&::-webkit-details-marker]:hidden";
+  "group/sum list-none grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-3 px-[2px] py-3 cursor-pointer border-0 rounded-none shadow-none bg-transparent min-h-0 [&::-webkit-details-marker]:hidden";
 export const ENTRY_DATE =
   "font-medium text-xs font-mono text-muted min-w-[110px] tabular-nums tracking-wide group-hover/sum:text-text";
 export const ENTRY_PREVIEW =
@@ -16,15 +16,15 @@ export const ENTRY_PREVIEW =
 export const ENTRY_CHEVRON =
   "text-muted-soft transition-transform duration-200 ease-[ease] text-nano group-open/row:rotate-90";
 export const ENTRY_EXPANDED =
-  "px-[2px] pt-inline pb-stack grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-stack";
-export const DETAIL_ACTIONS = "[grid-column:1/-1] flex gap-tight justify-end -mt-tight";
+  "px-[2px] pt-2 pb-3 grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3";
+export const DETAIL_ACTIONS = "[grid-column:1/-1] flex gap-1 justify-end -mt-1";
 export const DETAIL_ACTION_BTN =
-  "px-inline py-tight text-xs font-medium text-muted bg-transparent border-0 rounded-[6px] shadow-none cursor-pointer font-[inherit] transition-[color,background] duration-150 ease-[ease] hover:text-text hover:bg-[color-mix(in_srgb,var(--text)_8%,transparent)]";
+  "px-2 py-1 text-xs font-medium text-muted bg-transparent border-0 rounded-[6px] shadow-none cursor-pointer font-[inherit] transition-[color,background] duration-150 ease-[ease] hover:text-text hover:bg-[color-mix(in_srgb,var(--text)_8%,transparent)]";
 export const DELETE_CONFIRM = "text-danger-strong bg-danger-strong/18 font-extrabold";
 
 export function EntriesHeading({ children, className = "" }: { children: ReactNode; className?: string }) {
   return (
-    <h2 className={`text-control text-accent uppercase tracking-[0.16em] font-bold mt-page mb-stack ${className}`}>
+    <h2 className={`text-control text-accent uppercase tracking-[0.16em] font-bold mt-8 mb-3 ${className}`}>
       {children}
     </h2>
   );
@@ -58,7 +58,7 @@ export function PastEntriesColumn({
   return (
     <div
       ref={colRef}
-      className="min-w-0 min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-split min-[1100px]:flex min-[1100px]:flex-col min-[1100px]:min-h-[var(--diary-past-col-max-h,0)] min-[1100px]:max-h-[var(--diary-past-col-max-h,none)]"
+      className="min-w-0 min-[1100px]:border-l min-[1100px]:border-[var(--border-soft)] min-[1100px]:pl-12 min-[1100px]:flex min-[1100px]:flex-col min-[1100px]:min-h-[var(--diary-past-col-max-h,0)] min-[1100px]:max-h-[var(--diary-past-col-max-h,none)]"
     >
       {isLoading && <p className="text-muted text-control">{loadingText}</p>}
       <EntriesHeading className="min-[1100px]:mt-0">{title}</EntriesHeading>
@@ -68,15 +68,15 @@ export function PastEntriesColumn({
         <div className="min-[1100px]:flex min-[1100px]:flex-col min-[1100px]:flex-1 min-[1100px]:min-h-0">
           <div
             ref={bodyRef}
-            className="min-[1100px]:flex-1 min-[1100px]:min-h-0 min-[1100px]:overflow-hidden min-[1100px]:[mask-image:linear-gradient(to_bottom,#000_calc(100%-var(--spacing-block)),transparent)]"
+            className="min-[1100px]:flex-1 min-[1100px]:min-h-0 min-[1100px]:overflow-hidden min-[1100px]:[mask-image:linear-gradient(to_bottom,#000_calc(100%-20px),transparent)]"
           >
             {children}
           </div>
           <div
             aria-hidden={!overflow}
-            className="flex justify-end items-center pt-inline min-[1100px]:flex-shrink-0 min-[1100px]:box-border min-[1100px]:min-h-[calc(var(--spacing-inline)+40px+var(--spacing-block))]"
+            className="flex justify-end items-center pt-2 min-[1100px]:flex-shrink-0 min-[1100px]:box-border min-[1100px]:min-h-[calc(8px+40px+20px)]"
           >
-            {!isLoading && overflow ? <Button className="mb-block">Show more</Button> : null}
+            {!isLoading && overflow ? <Button className="mb-5">Show more</Button> : null}
           </div>
         </div>
       )}
@@ -86,11 +86,11 @@ export function PastEntriesColumn({
 
 // Inline tag chip inside an expanded entry's detail value (former .tag-mini).
 export const TAG_MINI =
-  "py-[2px] px-inline text-micro text-muted bg-[color-mix(in_srgb,var(--card)_60%,var(--card-strong))] rounded-[4px]";
+  "py-[2px] px-2 text-micro text-muted bg-[color-mix(in_srgb,var(--card)_60%,var(--card-strong))] rounded-[4px]";
 
 // Accent-underline tab button shape (no color), shared by TagTabs + Settings tabs.
 export const TAG_TAB_BTN =
-  "inline-flex items-center gap-inline py-tight px-0 text-control font-medium bg-transparent border-0 border-b rounded-none shadow-none cursor-pointer font-[inherit] whitespace-nowrap min-h-0 transition-[color,border-color] duration-150 ease-[ease]";
+  "inline-flex items-center gap-2 py-1 px-0 text-control font-medium bg-transparent border-0 border-b rounded-none shadow-none cursor-pointer font-[inherit] whitespace-nowrap min-h-0 transition-[color,border-color] duration-150 ease-[ease]";
 
 // Accent-underline tab strip shared by Diary (moods) and Pain (medicines).
 export function TagTabs<T extends string>({
@@ -105,7 +105,7 @@ export function TagTabs<T extends string>({
   ariaLabel: string;
 }) {
   return (
-    <nav className="flex flex-wrap gap-y-tight gap-x-block" role="tablist" aria-label={ariaLabel}>
+    <nav className="flex flex-wrap gap-y-1 gap-x-5" role="tablist" aria-label={ariaLabel}>
       {tabs.map((t) => (
         <button
           key={t.id}
@@ -136,9 +136,9 @@ export function TagList({ items }: { items: string[] }) {
 
 export function DetailGroup({ label, children }: { label: ReactNode; children: ReactNode }) {
   return (
-    <div className="grid gap-tight">
+    <div className="grid gap-1">
       <span className="text-micro text-muted uppercase tracking-wider">{label}</span>
-      <span className="text-control flex flex-wrap gap-tight text-text">{children}</span>
+      <span className="text-control flex flex-wrap gap-1 text-text">{children}</span>
     </div>
   );
 }
@@ -160,7 +160,7 @@ export function PainBadge({
   sm?: boolean;
   children: ReactNode;
 }) {
-  const size = sm ? "min-w-[24px] h-[24px] text-xs px-tight" : "min-w-[30px] h-[30px] text-sm px-inline";
+  const size = sm ? "min-w-[24px] h-[24px] text-xs px-1" : "min-w-[30px] h-[30px] text-sm px-2";
   return (
     <span className={`inline-flex items-center justify-center rounded-[8px] font-extrabold ${size} ${PAIN_BADGE[variant]}`}>
       {children}

--- a/frontend/src/app/memorable-days.tsx
+++ b/frontend/src/app/memorable-days.tsx
@@ -20,14 +20,14 @@ export const MEMO_LIST_ITEM =
   "flex items-center justify-between flex-[0_0_auto] w-full gap-3 p-3 rounded-md border-0 bg-card-soft text-text shadow-none hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
 const MEMO_MODAL_ACTIONS = "flex items-center gap-3 justify-end flex-wrap";
 const EMOJI_TAB =
-  "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
+  "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
 const EMOJI_BTN =
-  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-title leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
+  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-title leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
 // Exported so the Design System demo reuses the exact production contracts.
 export const DAY_NUMBER =
   "bg-transparent border-0 shadow-none min-h-0 p-0 font-[inherit] text-[inherit] cursor-pointer leading-none";
 export const EMOJI_TRIGGER =
-  "min-w-0 min-h-0 p-0 rounded-none inline-flex items-center justify-center bg-transparent border border-transparent text-text shadow-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
+  "min-w-0 min-h-0 p-0 rounded-none inline-flex items-center justify-center bg-transparent border border-transparent text-text shadow-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
 
 type Props = {
   memorable: ReturnType<typeof useMemorableDays>;

--- a/frontend/src/app/memorable-days.tsx
+++ b/frontend/src/app/memorable-days.tsx
@@ -556,6 +556,8 @@ export function MemorableDaysSection({ memorable }: Props) {
                         <span className={`${FIELD_LINE_LABEL} pt-0 pb-0`}>Search emoji</span>
                         <input
                           ref={emojiPickerSearchRef}
+                          id="emoji-search"
+                          name="emoji-search"
                           className="w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft"
                           type="search"
                           value={emojiPickerSearch}

--- a/frontend/src/app/memorable-days.tsx
+++ b/frontend/src/app/memorable-days.tsx
@@ -12,13 +12,13 @@ import { FieldLine, FIELD_LINE_LABEL } from "../components/ui/FieldLine";
 import { EntriesHeading } from "./entries";
 
 const MEMO_BACKDROP =
-  "fixed inset-0 bg-scrim [backdrop-filter:blur(6px)] grid place-items-center p-block z-40";
-const MEMO_MODAL = "w-[min(520px,100%)] p-block flex flex-col gap-stack bg-card border-0 rounded-md shadow-none";
+  "fixed inset-0 bg-scrim [backdrop-filter:blur(6px)] grid place-items-center p-5 z-40";
+const MEMO_MODAL = "w-[min(520px,100%)] p-5 flex flex-col gap-3 bg-card border-0 rounded-md shadow-none";
 export const MEMO_DAY_CELL =
-  "min-h-[108px] p-stack rounded-md bg-card-soft text-text text-left flex flex-col gap-inline relative transition-[background,color] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
+  "min-h-[108px] p-3 rounded-md bg-card-soft text-text text-left flex flex-col gap-2 relative transition-[background,color] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
 export const MEMO_LIST_ITEM =
-  "flex items-center justify-between flex-[0_0_auto] w-full gap-stack p-stack rounded-md border-0 bg-card-soft text-text shadow-none hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
-const MEMO_MODAL_ACTIONS = "flex items-center gap-stack justify-end flex-wrap";
+  "flex items-center justify-between flex-[0_0_auto] w-full gap-3 p-3 rounded-md border-0 bg-card-soft text-text shadow-none hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
+const MEMO_MODAL_ACTIONS = "flex items-center gap-3 justify-end flex-wrap";
 const EMOJI_TAB =
   "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
 const EMOJI_BTN =
@@ -397,19 +397,19 @@ export function MemorableDaysSection({ memorable }: Props) {
   };
 
   return (
-    <section className="@container p-inline relative">
+    <section className="@container p-2 relative">
       <div>
         <div>
-          <h1 className="m-0 mb-stack text-[22px] font-bold tracking-tight text-text">Memorable days</h1>
+          <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Memorable days</h1>
           <SectionHead title="Calendar" variant="dashboard" />
         </div>
       </div>
-      <Button variant="primary" className="absolute top-page right-inline" onClick={() => openCreate(toDateKey(new Date()))}>Add new</Button>
+      <Button variant="primary" className="absolute top-8 right-2" onClick={() => openCreate(toDateKey(new Date()))}>Add new</Button>
       {feedback?.tone === "error" ? <InlineFeedback message={feedback} /> : null}
 
-      <div className="grid gap-split items-start grid-cols-[minmax(0,1.55fr)_minmax(280px,0.9fr)] max-[1239px]:grid-cols-1 max-[1239px]:gap-0">
-        <section ref={leftColRef} className="min-w-0 p-0 max-[1239px]:border-b max-[1239px]:border-[var(--border-soft)] max-[1239px]:pb-page">
-          <div className="flex items-center justify-between gap-inline mb-page min-w-0">
+      <div className="grid gap-12 items-start grid-cols-[minmax(0,1.55fr)_minmax(280px,0.9fr)] max-[1239px]:grid-cols-1 max-[1239px]:gap-0">
+        <section ref={leftColRef} className="min-w-0 p-0 max-[1239px]:border-b max-[1239px]:border-[var(--border-soft)] max-[1239px]:pb-8">
+          <div className="flex items-center justify-between gap-2 mb-8 min-w-0">
             <Button className="flex-shrink-0 tracking-[0.01em]" onClick={() => memorable.setVisibleMonth(new Date(memorable.visibleMonth.getFullYear(), memorable.visibleMonth.getMonth() - 1, 1))}>
               Prev
             </Button>
@@ -424,10 +424,10 @@ export function MemorableDaysSection({ memorable }: Props) {
               Next
             </Button>
           </div>
-          <div className="flex items-center gap-inline mb-inline">
+          <div className="flex items-center gap-2 mb-2">
             {weekdayLabels.map((label) => <span key={label} className="flex-1 text-center text-muted text-xs font-bold uppercase">{label}</span>)}
           </div>
-          <div className="grid grid-cols-[repeat(7,minmax(0,1fr))] gap-inline">
+          <div className="grid grid-cols-[repeat(7,minmax(0,1fr))] gap-2">
             {days.map((day) => {
               const dayKey = toDateKey(day);
               const monthMatch = day.getMonth() === memorable.visibleMonth.getMonth();
@@ -462,7 +462,7 @@ export function MemorableDaysSection({ memorable }: Props) {
                       {day.getDate()}
                     </button>
                   </span>
-                  <span className="flex flex-col gap-inline">
+                  <span className="flex flex-col gap-2">
                     {items.slice(0, 2).map((item) => (
                       <span key={`${item.source}-${item.id}-${item.date}`} className="text-xs leading-snug text-muted whitespace-nowrap overflow-hidden text-ellipsis">
                         {item.emoji || "•"} {item.title}
@@ -478,17 +478,17 @@ export function MemorableDaysSection({ memorable }: Props) {
           </div>
         </section>
 
-        <section ref={rightColRef} className="min-w-0 flex flex-col min-h-0 overflow-hidden h-[var(--split-col-height,auto)] max-h-[var(--split-col-height,none)] max-[1239px]:h-auto max-[1239px]:max-h-none max-[1239px]:pt-block max-[980px]:pt-0">
-          <EntriesHeading className="mt-0 mb-block">All memorable days</EntriesHeading>
+        <section ref={rightColRef} className="min-w-0 flex flex-col min-h-0 overflow-hidden h-[var(--split-col-height,auto)] max-h-[var(--split-col-height,none)] max-[1239px]:h-auto max-[1239px]:max-h-none max-[1239px]:pt-5 max-[980px]:pt-0">
+          <EntriesHeading className="mt-0 mb-5">All memorable days</EntriesHeading>
           {memorable.isLoading ? (
             <p className="text-muted text-control">Loading memorable days...</p>
           ) : memorable.memorableDays.length === 0 ? (
-            <div className="grid gap-inline my-stack">
+            <div className="grid gap-2 my-3">
               <p className="text-control font-semibold text-text m-0">No memorable days yet</p>
               <p className="max-w-[60ch] text-control text-muted leading-normal m-0">Add one birthday, anniversary, or event to start the list.</p>
             </div>
           ) : (
-            <div className="memorable-list flex flex-col flex-[1_1_auto] min-h-0 overflow-y-auto overflow-x-hidden gap-stack [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent] max-[1239px]:max-h-none">
+            <div className="memorable-list flex flex-col flex-[1_1_auto] min-h-0 overflow-y-auto overflow-x-hidden gap-3 [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent] max-[1239px]:max-h-none">
               {memorable.memorableDays.map((item) => (
                 <button
                   type="button"
@@ -498,8 +498,8 @@ export function MemorableDaysSection({ memorable }: Props) {
                   onClick={() => openEdit(item)}
                 >
                   <span className="text-[22px] leading-none">{item.emoji || "✨"}</span>
-                  <span className="flex-1 flex flex-col gap-tight items-start">
-                    <span className="w-full flex items-baseline justify-between gap-stack">
+                  <span className="flex-1 flex flex-col gap-1 items-start">
+                    <span className="w-full flex items-baseline justify-between gap-3">
                       <strong className="text-base min-w-0 text-text">{item.title}</strong>
                       <span className="text-muted text-control flex-shrink-0 text-right">{item.date}</span>
                     </span>
@@ -516,12 +516,12 @@ export function MemorableDaysSection({ memorable }: Props) {
         <div className={MEMO_BACKDROP} role="presentation" onClick={closeDraft}>
           <div className={MEMO_MODAL} role="dialog" aria-modal="true" aria-label={draft.id ? "Edit memorable day" : "Add memorable day"} onClick={(event) => event.stopPropagation()}>
             <SectionHead title={draft.id ? "Edit memorable day" : "Add memorable day"} variant="dashboard" />
-            <div className="grid grid-cols-[168px_88px] gap-stack items-start justify-start">
-              <label className="grid gap-inline content-start min-w-0">
+            <div className="grid grid-cols-[168px_88px] gap-3 items-start justify-start">
+              <label className="grid gap-2 content-start min-w-0">
                 <span className={FIELD_LINE_LABEL}>Date</span>
                 <DateInput value={draft.date} onChange={(value) => setDraft((current) => current ? { ...current, date: value } : current)} ariaLabel="Date" />
               </label>
-              <label className="grid gap-inline content-start w-[88px] min-w-[88px] justify-self-end self-start">
+              <label className="grid gap-2 content-start w-[88px] min-w-[88px] justify-self-end self-start">
                 <span className={FIELD_LINE_LABEL}>Emoji</span>
                 <div ref={emojiPickerRef} className="relative w-full min-w-0">
                   <button
@@ -549,14 +549,14 @@ export function MemorableDaysSection({ memorable }: Props) {
                       id="emoji-picker-panel"
                       role="dialog"
                       aria-label="Emoji picker"
-                      className="absolute top-full mt-inline right-0 w-[min(420px,calc(100vw-32px))] max-w-[min(420px,calc(100vw-32px))] max-h-[min(520px,calc(100vh-180px))] flex flex-col gap-stack p-stack bg-card border border-border rounded-md shadow-[var(--shadow)] z-30"
+                      className="absolute top-full mt-2 right-0 w-[min(420px,calc(100vw-32px))] max-w-[min(420px,calc(100vw-32px))] max-h-[min(520px,calc(100vh-180px))] flex flex-col gap-3 p-3 bg-card border border-border rounded-md shadow-[var(--shadow)] z-30"
                       onMouseDown={(event) => event.stopPropagation()}
                     >
-                      <label className="grid gap-inline content-start m-0">
+                      <label className="grid gap-2 content-start m-0">
                         <span className={`${FIELD_LINE_LABEL} pt-0 pb-0`}>Search emoji</span>
                         <input
                           ref={emojiPickerSearchRef}
-                          className="w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-stack py-inline text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft"
+                          className="w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft"
                           type="search"
                           value={emojiPickerSearch}
                           onChange={(event) => setEmojiPicker((current) => ({ ...current, search: event.target.value }))}
@@ -564,7 +564,7 @@ export function MemorableDaysSection({ memorable }: Props) {
                         />
                       </label>
 
-                      <div role="tablist" aria-label="Emoji categories" className="flex flex-wrap gap-inline">
+                      <div role="tablist" aria-label="Emoji categories" className="flex flex-wrap gap-2">
                         {emojiCategoryOrder.map((category) => {
                           const isActive = emojiPickerActiveCategory === category;
                           const label = emojiCategoryLabels[category];
@@ -591,7 +591,7 @@ export function MemorableDaysSection({ memorable }: Props) {
                         className="min-h-0 max-h-[320px] overflow-auto [overscroll-behavior:contain] [scrollbar-width:thin] [scrollbar-gutter:stable] pr-[2px] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent]"
                       >
                         {emojiPickerRecords.length > 0 ? (
-                          <div className="flex flex-wrap gap-inline">
+                          <div className="flex flex-wrap gap-2">
                             {emojiPickerRecords.map((record) => {
                               const isSelected = draft.emoji === record.emoji;
                               return (
@@ -609,7 +609,7 @@ export function MemorableDaysSection({ memorable }: Props) {
                             })}
                           </div>
                         ) : (
-                          <p className="m-0 px-[2px] pt-inline pb-[2px] text-center text-muted-soft text-control">
+                          <p className="m-0 px-[2px] pt-2 pb-[2px] text-center text-muted-soft text-control">
                             No emoji match.
                           </p>
                         )}
@@ -633,7 +633,7 @@ export function MemorableDaysSection({ memorable }: Props) {
               value={draft.description}
               onChange={(event) => setDraft((current) => current ? { ...current, description: event.target.value } : current)}
             />
-            <div className="grid gap-inline content-start">
+            <div className="grid gap-2 content-start">
               <span className={FIELD_LINE_LABEL}>Repeat</span>
               <Select
                 ariaLabel="Repeat"
@@ -668,12 +668,12 @@ export function MemorableDaysSection({ memorable }: Props) {
         <div className={MEMO_BACKDROP} role="presentation" onClick={() => setPopoverDateKey(null)}>
           <div ref={popoverRef} className={MEMO_MODAL} role="dialog" aria-modal="true" aria-label={`Events on ${popoverDateKey}`} onClick={(event) => event.stopPropagation()}>
             <SectionHead title={popoverDateKey} variant="dashboard" />
-            <div className="flex flex-col gap-inline m-0 mb-inline">
+            <div className="flex flex-col gap-2 m-0 mb-2">
               {popoverItems.map((item) => (
                 <button
                   key={`${item.source}-${item.id}-${item.date}`}
                   type="button"
-                  className="flex items-center gap-stack bg-card-soft border-0 shadow-none min-h-0 p-[var(--spacing-inline)_var(--spacing-stack)] rounded-md text-text text-left cursor-pointer w-full transition-[background] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]"
+                  className="flex items-center gap-3 bg-card-soft border-0 shadow-none min-h-0 p-[8px_12px] rounded-md text-text text-left cursor-pointer w-full transition-[background] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]"
                   onClick={() => {
                     setPopoverDateKey(null);
                     openEdit(item);

--- a/frontend/src/app/memorable-days.tsx
+++ b/frontend/src/app/memorable-days.tsx
@@ -22,7 +22,7 @@ const MEMO_MODAL_ACTIONS = "flex items-center gap-3 justify-end flex-wrap";
 const EMOJI_TAB =
   "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
 const EMOJI_BTN =
-  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-[22px] leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
+  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-title leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_28%,transparent)]";
 // Exported so the Design System demo reuses the exact production contracts.
 export const DAY_NUMBER =
   "bg-transparent border-0 shadow-none min-h-0 p-0 font-[inherit] text-[inherit] cursor-pointer leading-none";
@@ -400,15 +400,15 @@ export function MemorableDaysSection({ memorable }: Props) {
     <section className="@container p-2 relative">
       <div>
         <div>
-          <h1 className="m-0 mb-3 text-[22px] font-bold tracking-tight text-text">Memorable days</h1>
+          <h1 className="m-0 mb-3 text-title font-bold tracking-tight text-text">Memorable days</h1>
           <SectionHead title="Calendar" variant="dashboard" />
         </div>
       </div>
       <Button variant="primary" className="absolute top-8 right-2" onClick={() => openCreate(toDateKey(new Date()))}>Add new</Button>
       {feedback?.tone === "error" ? <InlineFeedback message={feedback} /> : null}
 
-      <div className="grid gap-12 items-start grid-cols-[minmax(0,1.55fr)_minmax(280px,0.9fr)] max-[1239px]:grid-cols-1 max-[1239px]:gap-0">
-        <section ref={leftColRef} className="min-w-0 p-0 max-[1239px]:border-b max-[1239px]:border-[var(--border-soft)] max-[1239px]:pb-8">
+      <div className="grid gap-12 items-start grid-cols-[minmax(0,1.55fr)_minmax(280px,0.9fr)] max-xwide:grid-cols-1 max-xwide:gap-0">
+        <section ref={leftColRef} className="min-w-0 p-0 max-xwide:border-b max-xwide:border-border max-xwide:pb-8">
           <div className="flex items-center justify-between gap-2 mb-8 min-w-0">
             <Button className="flex-shrink-0 tracking-[0.01em]" onClick={() => memorable.setVisibleMonth(new Date(memorable.visibleMonth.getFullYear(), memorable.visibleMonth.getMonth() - 1, 1))}>
               Prev
@@ -478,7 +478,7 @@ export function MemorableDaysSection({ memorable }: Props) {
           </div>
         </section>
 
-        <section ref={rightColRef} className="min-w-0 flex flex-col min-h-0 overflow-hidden h-[var(--split-col-height,auto)] max-h-[var(--split-col-height,none)] max-[1239px]:h-auto max-[1239px]:max-h-none max-[1239px]:pt-5 max-[980px]:pt-0">
+        <section ref={rightColRef} className="min-w-0 flex flex-col min-h-0 overflow-hidden h-[var(--split-col-height,auto)] max-h-[var(--split-col-height,none)] max-xwide:h-auto max-xwide:max-h-none max-xwide:pt-5 max-[980px]:pt-0">
           <EntriesHeading className="mt-0 mb-5">All memorable days</EntriesHeading>
           {memorable.isLoading ? (
             <p className="text-muted text-control">Loading memorable days...</p>
@@ -488,7 +488,7 @@ export function MemorableDaysSection({ memorable }: Props) {
               <p className="max-w-[60ch] text-control text-muted leading-normal m-0">Add one birthday, anniversary, or event to start the list.</p>
             </div>
           ) : (
-            <div className="memorable-list flex flex-col flex-[1_1_auto] min-h-0 overflow-y-auto overflow-x-hidden gap-3 [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent] max-[1239px]:max-h-none">
+            <div className="memorable-list flex flex-col flex-[1_1_auto] min-h-0 overflow-y-auto overflow-x-hidden gap-3 [scrollbar-width:thin] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent] max-xwide:max-h-none">
               {memorable.memorableDays.map((item) => (
                 <button
                   type="button"
@@ -497,7 +497,7 @@ export function MemorableDaysSection({ memorable }: Props) {
                   onWheelCapture={onListItemWheel}
                   onClick={() => openEdit(item)}
                 >
-                  <span className="text-[22px] leading-none">{item.emoji || "✨"}</span>
+                  <span className="text-title leading-none">{item.emoji || "✨"}</span>
                   <span className="flex-1 flex flex-col gap-1 items-start">
                     <span className="w-full flex items-baseline justify-between gap-3">
                       <strong className="text-base min-w-0 text-text">{item.title}</strong>

--- a/frontend/src/app/screen-helpers.tsx
+++ b/frontend/src/app/screen-helpers.tsx
@@ -1,7 +1,7 @@
 import { bandNine, formatMetricDisplay } from "./screen-format";
 
 const STEPPER_BTN =
-  "w-6 h-6 min-h-6 p-0 text-sm text-muted bg-transparent border border-[var(--border-soft)] rounded-full shadow-none cursor-pointer transition-[color,border-color] duration-150 ease-[ease] hover:text-accent hover:bg-transparent hover:border-accent";
+  "w-6 h-6 min-h-6 p-0 text-sm text-muted bg-transparent border border-border rounded-full shadow-none cursor-pointer transition-[color,border-color] duration-150 ease-[ease] hover:text-accent hover:bg-transparent hover:border-accent";
 
 export function BarMetric({
   label,

--- a/frontend/src/app/screen-helpers.tsx
+++ b/frontend/src/app/screen-helpers.tsx
@@ -22,7 +22,7 @@ export function BarMetric({
   const band = bandNine(n, higherIsBetter);
   const bandColor = { low: "text-success", mid: "text-warning", high: "text-danger", "": "" }[band] ?? "";
   return (
-    <div className="grid grid-cols-[120px_1fr_auto] items-center gap-stack pb-[2px]">
+    <div className="grid grid-cols-[120px_1fr_auto] items-center gap-3 pb-[2px]">
       <span className="text-control font-medium text-text">{label}</span>
       <div className="grid grid-cols-9 gap-[2px]" role="group" aria-label={label}>
         {Array.from({ length: 9 }, (_, i) => {
@@ -65,10 +65,10 @@ export function BarMetric({
 export function CoffeeStepper({ value, onChange }: { value: number | null; onChange: (next: number | null) => void }) {
   const n = value != null && !Number.isNaN(Number(value)) ? Math.min(50, Math.max(0, Math.floor(Number(value)))) : 0;
   return (
-    <div className="grid grid-cols-[120px_1fr_auto] items-center gap-stack pb-[2px]">
+    <div className="grid grid-cols-[120px_1fr_auto] items-center gap-3 pb-[2px]">
       <span className="text-control font-medium text-text">Coffee</span>
       <span aria-hidden="true" className="h-2.5 min-h-2.5 bg-[color-mix(in_srgb,white_4%,var(--card))] rounded-xs" />
-      <div className="inline-flex items-center gap-inline">
+      <div className="inline-flex items-center gap-2">
         <button type="button" className={STEPPER_BTN} aria-label="Decrease coffee count" onClick={() => onChange(Math.max(0, n - 1))}>
           −
         </button>
@@ -93,7 +93,7 @@ export function EmptyState({
   compact?: boolean;
 }) {
   return (
-    <div className={compact ? "grid gap-inline m-0" : "grid gap-inline my-stack"}>
+    <div className={compact ? "grid gap-2 m-0" : "grid gap-2 my-3"}>
       <p className="text-control font-semibold text-text m-0">{title}</p>
       <p className="max-w-[60ch] text-control text-muted leading-normal m-0">{description}</p>
     </div>

--- a/frontend/src/app/screen-helpers.tsx
+++ b/frontend/src/app/screen-helpers.tsx
@@ -1,7 +1,7 @@
 import { bandNine, formatMetricDisplay } from "./screen-format";
 
 const STEPPER_BTN =
-  "w-[26px] h-[26px] min-h-[26px] p-0 text-sm text-muted bg-transparent border border-[var(--border-soft)] rounded-full shadow-none cursor-pointer transition-[color,border-color] duration-150 ease-[ease] hover:text-accent hover:bg-transparent hover:border-accent";
+  "w-6 h-6 min-h-6 p-0 text-sm text-muted bg-transparent border border-[var(--border-soft)] rounded-full shadow-none cursor-pointer transition-[color,border-color] duration-150 ease-[ease] hover:text-accent hover:bg-transparent hover:border-accent";
 
 export function BarMetric({
   label,
@@ -46,7 +46,7 @@ export function BarMetric({
             <button
               key={slot}
               type="button"
-              className={`h-[10px] min-h-[10px] p-0 border-0 rounded-[2px] shadow-none cursor-pointer transition-[background] duration-[120ms] appearance-none ${fill}`}
+              className={`h-2.5 min-h-2.5 p-0 border-0 rounded-xs shadow-none cursor-pointer transition-[background] duration-[120ms] appearance-none ${fill}`}
               aria-label={`${label} ${slot} of 9`}
               aria-pressed={n === slot}
               onClick={() => {
@@ -67,7 +67,7 @@ export function CoffeeStepper({ value, onChange }: { value: number | null; onCha
   return (
     <div className="grid grid-cols-[120px_1fr_auto] items-center gap-stack pb-[2px]">
       <span className="text-control font-medium text-text">Coffee</span>
-      <span aria-hidden="true" className="h-[10px] min-h-[10px] bg-[color-mix(in_srgb,white_4%,var(--card))] rounded-[2px]" />
+      <span aria-hidden="true" className="h-2.5 min-h-2.5 bg-[color-mix(in_srgb,white_4%,var(--card))] rounded-xs" />
       <div className="inline-flex items-center gap-inline">
         <button type="button" className={STEPPER_BTN} aria-label="Decrease coffee count" onClick={() => onChange(Math.max(0, n - 1))}>
           −

--- a/frontend/src/app/shared.tsx
+++ b/frontend/src/app/shared.tsx
@@ -8,21 +8,21 @@ import { csvToList, listToCsv, mergeOptions } from "./core";
 // Pill primitive shared by toggle/add/edit chips. Shape carries no color so
 // idle/active color utilities don't collide on source order.
 const CHIP_SHAPE =
-  "inline-flex items-center gap-inline px-stack py-tight min-h-page rounded-full text-hint leading-none border-0 shadow-none transition-[color,background] duration-150 ease-[ease]";
+  "inline-flex items-center gap-2 px-3 py-1 min-h-8 rounded-full text-hint leading-none border-0 shadow-none transition-[color,background] duration-150 ease-[ease]";
 const CHIP_IDLE = "text-muted bg-[color-mix(in_srgb,white_5%,var(--card))]";
 const CHIP_IDLE_HOVER = "hover:text-text hover:bg-[color-mix(in_srgb,white_9%,var(--card))]";
 const CHIP_ACTIVE = "text-accent bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]";
 const REMOVE_BTN =
   "inline-flex items-center justify-center w-[18px] h-[18px] min-h-[18px] p-0 rounded-full text-micro font-bold leading-none text-muted bg-[color-mix(in_srgb,var(--bg)_60%,transparent)] border-0 shadow-none flex-none cursor-pointer [@media(hover:hover)]:hover:text-danger [@media(hover:hover)]:hover:bg-[color-mix(in_srgb,var(--danger)_15%,transparent)]";
 const ADDER_BTN =
-  "border-0 bg-transparent px-stack py-tight min-h-[24px] rounded-full text-xs font-semibold font-body shadow-none cursor-pointer transition-[color,background] duration-150 ease-[ease]";
+  "border-0 bg-transparent px-3 py-1 min-h-[24px] rounded-full text-xs font-semibold font-body shadow-none cursor-pointer transition-[color,background] duration-150 ease-[ease]";
 
 type SectionHeadVariant = "default" | "dashboard" | "ds" | "tags";
 const SECTION_HEAD: Record<SectionHeadVariant, string> = {
-  default: "flex justify-between gap-stack pb-tight mt-block",
-  dashboard: "flex justify-between gap-stack pb-inline mt-block",
-  ds: "flex flex-col gap-[2px] pb-tight mt-block",
-  tags: "flex justify-between gap-stack mb-0",
+  default: "flex justify-between gap-3 pb-1 mt-5",
+  dashboard: "flex justify-between gap-3 pb-2 mt-5",
+  ds: "flex flex-col gap-[2px] pb-1 mt-5",
+  tags: "flex justify-between gap-3 mb-0",
 };
 const SECTION_TITLE: Record<SectionHeadVariant, string> = {
   default: "text-nano font-bold tracking-[0.16em] uppercase text-muted",
@@ -231,9 +231,9 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
   };
 
   return (
-    <div className="grid gap-inline content-start">
-      {hideLabel ? null : <span className="flex flex-wrap mt-stack mb-stack pl-stack border-l-[3px] border-accent text-sm font-semibold text-accent leading-tight">{label}</span>}
-      <div className="flex flex-wrap gap-inline content-start mt-[5px] mb-[5px] order-1" role="group" aria-label={label}>
+    <div className="grid gap-2 content-start">
+      {hideLabel ? null : <span className="flex flex-wrap mt-3 mb-3 pl-3 border-l-[3px] border-accent text-sm font-semibold text-accent leading-tight">{label}</span>}
+      <div className="flex flex-wrap gap-2 content-start mt-[5px] mb-[5px] order-1" role="group" aria-label={label}>
         {allOptions.map((option) => {
           const optionKey = option.toLowerCase();
           const isSelected = selectedSet.has(optionKey);
@@ -241,20 +241,20 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
 
           if (isConfirmingRemoval) {
             return (
-              <div key={option} className="inline-flex items-center gap-inline flex-wrap px-stack py-inline border border-[color-mix(in_srgb,var(--danger)_50%,transparent)] rounded-full bg-[color-mix(in_srgb,var(--danger)_8%,transparent)]" role="group" aria-label={`Confirm removal of ${option}`}>
+              <div key={option} className="inline-flex items-center gap-2 flex-wrap px-3 py-2 border border-[color-mix(in_srgb,var(--danger)_50%,transparent)] rounded-full bg-[color-mix(in_srgb,var(--danger)_8%,transparent)]" role="group" aria-label={`Confirm removal of ${option}`}>
                 <span className="whitespace-nowrap text-text text-control">Remove {option}?</span>
-                <div className="inline-flex items-center gap-inline">
+                <div className="inline-flex items-center gap-2">
                   <button
                     type="button"
                     ref={confirmRemoveRef}
-                    className="danger min-h-page px-stack py-tight text-xs shadow-none"
+                    className="danger min-h-8 px-3 py-1 text-xs shadow-none"
                     onClick={() => {
                       void permanentlyRemoveOption(option);
                     }}
                   >
                     Remove
                   </button>
-                  <button type="button" className="min-h-page px-stack py-tight text-xs shadow-none" onClick={() => setPendingRemovalKey(null)}>
+                  <button type="button" className="min-h-8 px-3 py-1 text-xs shadow-none" onClick={() => setPendingRemovalKey(null)}>
                     Cancel
                   </button>
                 </div>
@@ -290,9 +290,9 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
           );
         })}
       </div>
-      <div className="flex flex-wrap items-center gap-inline mt-tight">
+      <div className="flex flex-wrap items-center gap-2 mt-1">
         {addingOption ? (
-          <div className="inline-flex items-center gap-inline pl-stack pr-tight py-[2px] border border-[color-mix(in_srgb,var(--accent)_40%,transparent)] rounded-full bg-[color-mix(in_srgb,var(--accent)_6%,transparent)] min-h-page">
+          <div className="inline-flex items-center gap-2 pl-3 pr-1 py-[2px] border border-[color-mix(in_srgb,var(--accent)_40%,transparent)] rounded-full bg-[color-mix(in_srgb,var(--accent)_6%,transparent)] min-h-8">
             <input
               ref={addInputRef}
               autoFocus
@@ -346,7 +346,7 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
             </button>
             <button
               type="button"
-              className={`border-0 rounded-full px-stack py-tight min-h-page text-hint font-medium leading-none shadow-none cursor-pointer transition-[color,background] duration-150 ease-[ease] ${editOptionsMode ? "text-accent bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]" : "text-muted-soft bg-[color-mix(in_srgb,white_5%,var(--card))] hover:text-text hover:bg-[color-mix(in_srgb,white_9%,var(--card))]"}`}
+              className={`border-0 rounded-full px-3 py-1 min-h-8 text-hint font-medium leading-none shadow-none cursor-pointer transition-[color,background] duration-150 ease-[ease] ${editOptionsMode ? "text-accent bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]" : "text-muted-soft bg-[color-mix(in_srgb,white_5%,var(--card))] hover:text-text hover:bg-[color-mix(in_srgb,white_9%,var(--card))]"}`}
               aria-pressed={editOptionsMode}
               onClick={() => setEditMode(!editOptionsMode)}
             >

--- a/frontend/src/app/shared.tsx
+++ b/frontend/src/app/shared.tsx
@@ -359,14 +359,12 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
   );
 }
 
-/** Small titled divider used to group sub-sections across pages. When `ruled`,
- * a hairline fills the space after the title. */
-export function SectionHead({ title, aside, ruled = false, variant = "default" }: { title: string; aside?: ReactNode; ruled?: boolean; variant?: SectionHeadVariant }) {
-  const align = ruled ? "items-center" : variant === "ds" ? "items-start" : "items-baseline";
+/** Small titled divider used to group sub-sections across pages. */
+export function SectionHead({ title, aside, variant = "default" }: { title: string; aside?: ReactNode; variant?: SectionHeadVariant }) {
+  const align = variant === "ds" ? "items-start" : "items-baseline";
   return (
     <div className={`${SECTION_HEAD[variant]} ${align}`}>
       <span className={SECTION_TITLE[variant]}>{title}</span>
-      {ruled ? <span className="flex-1 h-px bg-border" aria-hidden="true" /> : null}
       {aside != null ? <span className={SECTION_ASIDE[variant]}>{aside}</span> : null}
     </div>
   );

--- a/frontend/src/app/shared.tsx
+++ b/frontend/src/app/shared.tsx
@@ -297,7 +297,7 @@ export function MultiSelectField({ label, fieldKey, value, options, onChange, do
               ref={addInputRef}
               autoFocus
               type="text"
-              className="flex-[1_1_140px] min-w-[120px] max-w-[18rem] w-auto border-0 bg-transparent p-0 text-text text-control font-medium font-body shadow-none outline-none focus:bg-transparent focus:shadow-none placeholder:text-muted-soft"
+              className="flex-[1_1_140px] min-w-30 max-w-72 w-auto border-0 bg-transparent p-0 text-text text-control font-medium font-body shadow-none outline-none focus:bg-transparent focus:shadow-none placeholder:text-muted-soft"
               placeholder={`New ${label.toLowerCase()}`}
               value={customValue}
               onChange={(event) => setCustomValue(event.target.value)}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ export type ButtonSize = "md" | "sm";
 // Pill button (former .btn / .btn-primary / .btn-danger / .is-success-pulse).
 // Shape carries no color so per-variant color/hover never collide on source order.
 const COMMON =
-  "font-semibold font-body border-0 rounded-full cursor-pointer shadow-none transition-[background,color] duration-150 ease-[ease] focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_38%,transparent)]";
+  "font-semibold font-body border-0 rounded-full cursor-pointer shadow-none transition-[background,color] duration-150 ease-[ease] focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
 
 const SIZE: Record<ButtonSize, string> = {
   md: "px-5 py-3 min-h-[40px] text-sm",

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -9,7 +9,7 @@ const COMMON =
   "font-semibold font-body border-0 rounded-full cursor-pointer shadow-none transition-[background,color] duration-150 ease-[ease] focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_38%,transparent)]";
 
 const SIZE: Record<ButtonSize, string> = {
-  md: "px-block py-stack min-h-[40px] text-sm",
+  md: "px-5 py-3 min-h-[40px] text-sm",
   sm: "inline-flex items-center justify-center px-[14px] py-[6px] min-h-[34px] text-control",
 };
 

--- a/frontend/src/components/ui/DateInput.tsx
+++ b/frontend/src/components/ui/DateInput.tsx
@@ -5,7 +5,7 @@ import { FIELD_LINE_INPUT } from "./FieldLine";
 // surface, themed (inverted) calendar-picker indicator. One picker style across
 // the whole app — no bespoke calendar popover.
 const DATE_INPUT =
-  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-inline [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
+  "!w-auto max-w-full justify-self-start cursor-pointer tabular-nums [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:ml-2 [&::-webkit-calendar-picker-indicator]:invert [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100";
 
 type DateInputProps = {
   value: string;

--- a/frontend/src/components/ui/FieldLine.tsx
+++ b/frontend/src/components/ui/FieldLine.tsx
@@ -4,9 +4,9 @@ import type { InputHTMLAttributes, ReactNode, TextareaHTMLAttributes } from "rea
 // a borderless tinted input/textarea. Renders the control itself so the input
 // styling lives in one place; spread rhf register() props straight onto it.
 export const FIELD_LINE_LABEL =
-  "pt-stack pb-inline text-nano font-bold tracking-[0.16em] uppercase text-muted";
+  "pt-3 pb-2 text-nano font-bold tracking-[0.16em] uppercase text-muted";
 export const FIELD_LINE_INPUT =
-  "w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-stack py-inline text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft [[data-theme=oled]_&]:hover:bg-[color-mix(in_srgb,white_6%,var(--card-soft))] [[data-theme=oled]_&]:focus:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]";
+  "w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft [[data-theme=oled]_&]:hover:bg-[color-mix(in_srgb,white_6%,var(--card-soft))] [[data-theme=oled]_&]:focus:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]";
 
 type FieldLineProps = InputHTMLAttributes<HTMLInputElement> &
   TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -19,7 +19,7 @@ type FieldLineProps = InputHTMLAttributes<HTMLInputElement> &
 export function FieldLine({ label, multiline = false, compact = false, className = "", ...rest }: FieldLineProps) {
   const minH = compact ? "min-h-[54px]" : "min-h-[64px]";
   return (
-    <label className="grid gap-inline content-start">
+    <label className="grid gap-2 content-start">
       <span className={FIELD_LINE_LABEL}>{label}</span>
       {multiline ? (
         // rest is the input∩textarea intersection; narrow to the rendered element.

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -112,7 +112,7 @@ export function Select({ value, onValueChange, options, ariaLabel, disabled, pla
       <button
         ref={triggerRef}
         type="button"
-        className="appearance-none inline-flex items-center justify-between gap-inline w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-stack py-inline text-text text-control font-medium font-body cursor-pointer text-left transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus-visible:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus-visible:shadow-[inset_0_0_0_1px_var(--accent)] focus-visible:outline-none disabled:cursor-not-allowed disabled:text-muted-soft data-[empty=true]:text-muted-soft [[data-theme=oled]_&]:bg-card-soft [[data-theme=oled]_&]:hover:bg-[color-mix(in_srgb,white_6%,var(--card-soft))] [[data-theme=oled]_&]:focus-visible:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]"
+        className="appearance-none inline-flex items-center justify-between gap-2 w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body cursor-pointer text-left transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus-visible:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus-visible:shadow-[inset_0_0_0_1px_var(--accent)] focus-visible:outline-none disabled:cursor-not-allowed disabled:text-muted-soft data-[empty=true]:text-muted-soft [[data-theme=oled]_&]:bg-card-soft [[data-theme=oled]_&]:hover:bg-[color-mix(in_srgb,white_6%,var(--card-soft))] [[data-theme=oled]_&]:focus-visible:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]"
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -132,7 +132,7 @@ export function Select({ value, onValueChange, options, ariaLabel, disabled, pla
         <ul
           ref={listboxRef}
           id={listboxId}
-          className="absolute top-[calc(100%+var(--spacing-tight))] left-0 z-40 min-w-full m-0 list-none bg-card-strong border border-border rounded-md shadow-[var(--shadow)] p-tight grid gap-tight outline-none"
+          className="absolute top-[calc(100%+4px)] left-0 z-40 min-w-full m-0 list-none bg-card-strong border border-border rounded-md shadow-[var(--shadow)] p-1 grid gap-1 outline-none"
           role="listbox"
           aria-label={ariaLabel}
           aria-activedescendant={`${optionBaseId}-${activeIndex}`}
@@ -143,7 +143,7 @@ export function Select({ value, onValueChange, options, ariaLabel, disabled, pla
             <li
               key={option.value}
               id={`${optionBaseId}-${index}`}
-              className="flex items-center px-stack py-inline rounded-sm text-text text-control font-medium font-body cursor-pointer select-none data-[active=true]:bg-[color-mix(in_srgb,white_6%,var(--bg))] aria-selected:bg-accent aria-selected:text-text [[data-theme=oled]_&]:data-[active=true]:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]"
+              className="flex items-center px-3 py-2 rounded-sm text-text text-control font-medium font-body cursor-pointer select-none data-[active=true]:bg-[color-mix(in_srgb,white_6%,var(--bg))] aria-selected:bg-accent aria-selected:text-text [[data-theme=oled]_&]:data-[active=true]:bg-[color-mix(in_srgb,white_6%,var(--card-soft))]"
               role="option"
               aria-selected={option.value === value}
               data-active={index === activeIndex ? "true" : undefined}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -88,6 +88,9 @@
   --warning: #f5a623;
   --shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
   --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.25);
+  /* Keyboard focus ring — single source for the accent halo on focus-visible
+     (shadow-[0_0_0_2px_var(--ring)]). Unifies the former 28%/38% one-offs. */
+  --ring: color-mix(in srgb, var(--accent) 38%, transparent);
 }
 
 /* Theme variants — base :root above is the default "dark" theme. */
@@ -118,4 +121,15 @@ body {
   background: var(--bg);
 }
 
+}
+
+/* Accessibility: honor the OS "reduce motion" setting. Unlayered + !important
+   so it overrides the utility transitions/animations on every element. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,18 +1,14 @@
 @import "tailwindcss";
 
 /*
- * Tailwind v4 design tokens (#159). These generate the utilities the whole
- * app is built from (p-stack, gap-inline, text-control, rounded-md, font-body).
- * The former hand-rolled --layout-* spacing tokens were fully migrated to this
- * --spacing-* scale, which is now the single source of truth for spacing.
+ * Tailwind v4 design tokens. These generate the utilities the whole app is
+ * built from (text-control, rounded-md, font-body, mobile:). Spacing uses
+ * Tailwind's built-in numeric scale (p-3, gap-2, …) off the base --spacing,
+ * so no named spacing tokens live here.
  */
 @theme {
-  --spacing-tight: 4px;
-  --spacing-inline: 8px;
-  --spacing-stack: 12px;
-  --spacing-block: 20px;
-  --spacing-page: 30px;
-  --spacing-split: 48px;
+  /* Single named breakpoint for the mobile/desktop split (mobile:, max-mobile:). */
+  --breakpoint-mobile: 720px;
 
   /* Typography. 12/14/16px map 1:1 to Tailwind's built-in text-xs/sm/base,
      so only the off-scale sizes get a named token here. A named token (not

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -7,8 +7,11 @@
  * so no named spacing tokens live here.
  */
 @theme {
-  /* Single named breakpoint for the mobile/desktop split (mobile:, max-mobile:). */
+  /* Named breakpoints: mobile/desktop split (mobile:), the two-column split
+     (wide:), and the content cap (xwide:). max-* variants are auto-derived. */
   --breakpoint-mobile: 720px;
+  --breakpoint-wide: 1100px;
+  --breakpoint-xwide: 1240px;
 
   /* Typography. 12/14/16px map 1:1 to Tailwind's built-in text-xs/sm/base,
      so only the off-scale sizes get a named token here. A named token (not
@@ -17,6 +20,7 @@
   --text-micro: 11px; /* micro labels, badges, field-line caps */
   --text-hint: 12.5px; /* hints, therapy callouts */
   --text-control: 13px; /* compact date/select control text */
+  --text-title: 22px; /* page h1 */
 
   /* Radius — single-sourced here (formerly duplicated in :root). */
   --radius-sm: 10px;
@@ -78,7 +82,6 @@
   --muted: #a1a1ad;
   --muted-soft: #6d6d78;
   --border: #48484f;
-  --border-soft: #48484f;
   --accent: #ff5e8a;
   --danger: #ff5a7f;
   --success: #6fe1b0;


### PR DESCRIPTION
Follows the Tailwind v4 migration (#170). Finishes the design-system cleanup tracked in #171: removes the parallel token scale, tokenizes what was repeated, and prunes stale/dead bits.

## What changed
- **Spacing → Tailwind numeric scale.** Drops the six named `--spacing-*` tokens (tight/inline/stack/block/page/split); usages move to the built-in numeric utilities off the base `--spacing` (`gap-3` = 12px, `p-2` = 8px…). `page` (30px) has no integer step on the 4px grid (30/4 = 7.5, which v4 does **not** emit), so it rounds to 32px (`-8`). Direct `var(--spacing-*)` inside arbitrary `calc()`/`clamp()` become literal px.
- **Snap minimal-diff arbitrary values to tokens.** `w-[26px]`→`w-6`, `rounded-[2px]`→`rounded-xs`, `min-w-[120px]`→`min-w-30`, `translate-y-[2px]`→`translate-y-0.5`, etc. Genuinely distinct layout values (chart heights, flex basis) stay arbitrary.
- **Named breakpoints.** Adds `--breakpoint-mobile` (720), `--breakpoint-wide` (1100), `--breakpoint-xwide` (1240); migrates the repeated `max-[720px]` / `min-[1100px]` / `max-[1099px]` / `max-[1239px]` arbitraries to `mobile:` / `wide:` / `max-wide:` / `max-xwide:` variants. The lone `max-[980px]` (single use) stays arbitrary.
- **Type + color tokens.** Adds `--text-title` (22px) for the page `<h1>`s. Folds `--border-soft` into `--border` (they were the same value, so "hairlines" were never visually distinct) — `border-[var(--border-soft)]` becomes the `border-border` utility. Removes the stale `--accent-2` design-page swatch (the token was never defined).
- **Focus + motion + elevation.** Adds a `--ring` token that unifies the scattered 28%/38%/40% accent focus halos into one `focus-visible:shadow-[0_0_0_2px_var(--ring)]`; adds a global `prefers-reduced-motion` block (was entirely absent); documents `--shadow-sm`/`--shadow`/`--ring` in a new Elevation section on the design-system page.
- **Design-system page prune.** Drops the Spacing px-bar and Radius reference sections (utility names self-document the scale).
- **Remove the SectionHead `ruled` divider** (pre-existing from #170, unwanted): the prop and its three call sites (Settings Birthday/Theme, Medicine preselection) are gone.

## Why
`styles.css` still carried a parallel named spacing scale and a few dead/duplicate tokens after #170. Moving to Tailwind's numeric scale removes the indirection, tokenizes the repeated breakpoints/focus styles, and deletes what wasn't pulling its weight.

## Verification
- `build` (tsc + vite) + `lint` (eslint) + **vitest** (71) all green.
- Built CSS grepped to confirm every introduced utility actually generates (Tailwind silently drops unknown classes — notably fractional `7.5` does not generate, which is why `page` rounded to `-8`).
- Browser-verified spacing parity, the two-column `wide:` split + `border-border` divider, dark/oled theming, and the new Elevation section.

## Reviewer note
Opus diff-review verdict: **pass** — 0 critical, 0 security, 0 AGENTS.md violations, tests passed. Non-blocking notes (all intentional + documented in commits): `max-[980px]` left arbitrary (single use, §2/§3); the `mobile:` cutover shifts the old 720/721 boundary 1px (v4 generates complementary queries, no overlap/gap); the focus-ring unification collapses the old halo opacities to one value by design.

Closes #171