### PR TITLE
fix: deferred codebase-analyst findings (issue #175)

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -16,6 +16,10 @@ export const envSchema = z.object({
 
 export const env = envSchema.parse(process.env);
 
+if (!env.COOKIE_SECURE && process.env.NODE_ENV === "production") {
+  throw new Error("COOKIE_SECURE must be true in production");
+}
+
 export const allowedOrigins = new Set(
   env.ALLOWED_ORIGINS.split(",")
     .map((value) => value.trim())

--- a/backend/src/routes/pain.ts
+++ b/backend/src/routes/pain.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, desc, sql } from "drizzle-orm";
+import { eq, and, between, gte, lte, desc, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { DrizzleDB } from "../db/index.ts";
 import { painEntries, painOptions } from "../db/index.ts";
@@ -8,6 +8,7 @@ import type { SQLiteDB } from "../db.ts";
 import {
   parseJson,
   parseIdParam,
+  DATE_RE,
   PAIN_MULTI_FIELDS,
   type PainMultiField,
   type PainTagMap,
@@ -128,10 +129,26 @@ pain.post("/options/restore", async (c) => {
 pain.get("/", (c) => {
   const db = c.get("db");
   const userId = c.get("userId");
+  const from = c.req.query("from");
+  const to = c.req.query("to");
+
+  if ((from && !DATE_RE.test(from)) || (to && !DATE_RE.test(to))) {
+    return c.json({ error: { code: "INVALID_DATE", message: "from/to must be YYYY-MM-DD" } }, 400);
+  }
+
+  const conditions = [eq(painEntries.userId, userId)];
+  if (from && to) {
+    conditions.push(between(painEntries.entryDate, from, to));
+  } else if (from) {
+    conditions.push(gte(painEntries.entryDate, from));
+  } else if (to) {
+    conditions.push(lte(painEntries.entryDate, to));
+  }
+
   const rows = db
     .select()
     .from(painEntries)
-    .where(eq(painEntries.userId, userId))
+    .where(and(...conditions))
     .orderBy(desc(painEntries.entryDate), desc(painEntries.entryTime), desc(painEntries.id))
     .all();
   return c.json({ data: rows.map((row) => painRowToApi(row)) });

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -90,8 +90,8 @@ export const dbtSchema = z.object({
 
 export const prefsSchema = z.object({
   model: z.string().max(200).default(DEFAULT_MODEL),
-  chatRange: z.string().default("all"),
-  lastRange: z.string().default("all"),
+  chatRange: z.string().max(50).default("all"),
+  lastRange: z.string().max(50).default("all"),
   graphSelection: z.record(z.string(), z.unknown()).default({}),
   birthday: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(isoDateRefine, {
     message: "Invalid birthday: must be a valid calendar date in YYYY-MM-DD format"

--- a/frontend/src/app/memorable-day-modal.tsx
+++ b/frontend/src/app/memorable-day-modal.tsx
@@ -14,6 +14,7 @@ import {
   MEMO_BACKDROP,
   MEMO_MODAL,
   MEMO_MODAL_ACTIONS,
+  REPEAT_OPTIONS,
 } from "./memorable-days-constants";
 
 const EMOJI_TAB =
@@ -42,12 +43,6 @@ type EmojiPickerState = {
 };
 
 const emojiCategoryOrder = Object.keys(emojiCategoryLabels) as EmojiCategory[];
-
-export const REPEAT_OPTIONS: { value: DraftState["repeatMode"]; label: string }[] = [
-  { value: "one-time", label: "One-time" },
-  { value: "monthly", label: "Monthly" },
-  { value: "yearly", label: "Yearly" },
-];
 
 function createEmojiPickerScrollTopByCategory(): EmojiPickerScrollTopByCategory {
   return { recent: 0, smileys: 0, people: 0, nature: 0, food: 0, travel: 0, objects: 0, symbols: 0, flags: 0 };

--- a/frontend/src/app/memorable-day-modal.tsx
+++ b/frontend/src/app/memorable-day-modal.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { z } from "zod";
+import { SectionHead, InlineFeedback } from "./shared";
+import type { InlineMessage } from "./core";
+import { emojiCatalog, emojiCategoryLabels, type EmojiCategory, type EmojiRecord } from "./emoji-catalog";
+import { getErrorMessage } from "../lib";
+import { memorableDayPayloadSchema } from "../hooks/use-memorable-days";
+import { DateInput } from "../components/ui/DateInput";
+import { Select } from "../components/ui/select";
+import { Button, buttonClass } from "../components/ui/Button";
+import { FieldLine, FIELD_LINE_LABEL } from "../components/ui/FieldLine";
+import {
+  EMOJI_TRIGGER,
+  MEMO_BACKDROP,
+  MEMO_MODAL,
+  MEMO_MODAL_ACTIONS,
+} from "./memorable-days-constants";
+
+const EMOJI_TAB =
+  "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
+const EMOJI_BTN =
+  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-title leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
+
+export type DraftState = {
+  id: number | null;
+  date: string;
+  title: string;
+  emoji: string;
+  description: string;
+  repeatMode: "one-time" | "monthly" | "yearly";
+  locked: boolean;
+};
+
+type EmojiPickerScrollTopByCategory = Record<EmojiCategory, number>;
+
+type EmojiPickerState = {
+  open: boolean;
+  activeCategory: EmojiCategory;
+  search: string;
+  recent: string[];
+  scrollTopByCategory: EmojiPickerScrollTopByCategory;
+};
+
+const emojiCategoryOrder = Object.keys(emojiCategoryLabels) as EmojiCategory[];
+
+export const REPEAT_OPTIONS: { value: DraftState["repeatMode"]; label: string }[] = [
+  { value: "one-time", label: "One-time" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+function createEmojiPickerScrollTopByCategory(): EmojiPickerScrollTopByCategory {
+  return { recent: 0, smileys: 0, people: 0, nature: 0, food: 0, travel: 0, objects: 0, symbols: 0, flags: 0 };
+}
+
+function createEmojiPickerState(): EmojiPickerState {
+  return { open: false, activeCategory: "recent", search: "", recent: [], scrollTopByCategory: createEmojiPickerScrollTopByCategory() };
+}
+
+function getDraftErrorMessage(error: unknown) {
+  if (error instanceof z.ZodError) {
+    const titleIssue = error.issues.find((issue) => issue.path[0] === "title");
+    if (titleIssue) return "Title is required.";
+    const dateIssue = error.issues.find((issue) => issue.path[0] === "date");
+    if (dateIssue) return "Date is invalid.";
+    return "Check the form fields and try again.";
+  }
+  return getErrorMessage(error);
+}
+
+const emojiByValue = new Map(emojiCatalog.map((record) => [record.emoji, record]));
+const emojiRecordsByCategory = (() => {
+  const grouped = {
+    smileys: [] as EmojiRecord[], people: [] as EmojiRecord[], nature: [] as EmojiRecord[],
+    food: [] as EmojiRecord[], travel: [] as EmojiRecord[], objects: [] as EmojiRecord[],
+    symbols: [] as EmojiRecord[], flags: [] as EmojiRecord[],
+  };
+  for (const record of emojiCatalog) {
+    grouped[record.category].push(record);
+  }
+  return grouped;
+})();
+
+type Props = {
+  initialDraft: DraftState;
+  isSaving: boolean;
+  onSave: (draft: DraftState) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
+  onClose: () => void;
+  onDraftDateChange: (date: string) => void;
+};
+
+export function MemorableDayModal({ initialDraft, isSaving, onSave, onDelete, onClose, onDraftDateChange }: Props) {
+  const [draft, setDraft] = useState<DraftState>(initialDraft);
+  const [feedback, setFeedback] = useState<InlineMessage | null>(null);
+  const [emojiPicker, setEmojiPicker] = useState<EmojiPickerState>(() => createEmojiPickerState());
+  const emojiPickerRef = useRef<HTMLDivElement | null>(null);
+  const emojiPickerScrollRef = useRef<HTMLDivElement | null>(null);
+  const emojiPickerSearchRef = useRef<HTMLInputElement | null>(null);
+  const emojiPickerWasOpenRef = useRef(false);
+
+  const {
+    open: emojiPickerOpen,
+    activeCategory: emojiPickerActiveCategory,
+    search: emojiPickerSearch,
+    recent: emojiPickerRecent,
+    scrollTopByCategory: emojiPickerScrollTopByCategory,
+  } = emojiPicker;
+
+  const emojiPickerRecords = (() => {
+    const search = emojiPickerSearch.trim().toLowerCase();
+    if (search) {
+      return emojiCatalog.filter((record) => record.searchText.includes(search));
+    }
+    return emojiPickerActiveCategory === "recent"
+      ? emojiPickerRecent.map((emoji) => emojiByValue.get(emoji)).filter((record): record is EmojiRecord => Boolean(record))
+      : emojiRecordsByCategory[emojiPickerActiveCategory];
+  })();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !emojiPickerOpen) onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [emojiPickerOpen, onClose]);
+
+  useEffect(() => {
+    if (!emojiPickerOpen) return;
+    const savedScrollTop = emojiPickerScrollTopByCategory[emojiPickerActiveCategory] ?? 0;
+    const wasOpen = emojiPickerWasOpenRef.current;
+    emojiPickerWasOpenRef.current = true;
+    const frame = window.requestAnimationFrame(() => {
+      if (!wasOpen && emojiPickerSearchRef.current) {
+        emojiPickerSearchRef.current.focus();
+      }
+      if (emojiPickerScrollRef.current) {
+        emojiPickerScrollRef.current.scrollTop = savedScrollTop;
+      }
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [emojiPickerActiveCategory, emojiPickerOpen, emojiPickerScrollTopByCategory]);
+
+  useEffect(() => {
+    if (emojiPickerOpen) return;
+    emojiPickerWasOpenRef.current = false;
+  }, [emojiPickerOpen]);
+
+  useEffect(() => {
+    if (!draft.date) return;
+    onDraftDateChange(draft.date);
+  }, [draft.date, onDraftDateChange]);
+
+  const rememberEmojiPickerScrollTop = useCallback(() => {
+    const scroller = emojiPickerScrollRef.current;
+    if (!scroller) return;
+    const nextScrollTop = scroller.scrollTop;
+    setEmojiPicker((current) => {
+      const currentScrollTop = current.scrollTopByCategory[current.activeCategory] ?? 0;
+      if (currentScrollTop === nextScrollTop) return current;
+      return { ...current, scrollTopByCategory: { ...current.scrollTopByCategory, [current.activeCategory]: nextScrollTop } };
+    });
+  }, []);
+
+  const closeEmojiPicker = useCallback(() => {
+    rememberEmojiPickerScrollTop();
+    setEmojiPicker((current) => ({ ...current, open: false }));
+  }, [rememberEmojiPickerScrollTop]);
+
+  useEffect(() => {
+    if (!emojiPickerOpen) return;
+    const onMouseDown = (event: MouseEvent) => {
+      if (emojiPickerRef.current?.contains(event.target as Node)) return;
+      closeEmojiPicker();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeEmojiPicker();
+    };
+    window.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [closeEmojiPicker, emojiPickerOpen]);
+
+  const openEmojiPicker = () => {
+    setEmojiPicker((current) => ({ ...current, open: true }));
+    emojiPickerWasOpenRef.current = false;
+  };
+
+  const selectEmoji = (record: EmojiRecord) => {
+    setDraft((current) => ({ ...current, emoji: record.emoji }));
+    setEmojiPicker((current) => ({
+      ...current,
+      recent: [record.emoji, ...current.recent.filter((emoji) => emoji !== record.emoji)].slice(0, 24),
+    }));
+    closeEmojiPicker();
+  };
+
+  const handleSave = async () => {
+    try {
+      const payload = memorableDayPayloadSchema.parse({
+        date: draft.date, title: draft.title, emoji: draft.emoji,
+        description: draft.description, repeatMode: draft.repeatMode,
+      });
+      await onSave({ ...draft, ...payload });
+    } catch (error) {
+      setFeedback({ tone: "error", text: getDraftErrorMessage(error) });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!draft.id) return;
+    try {
+      await onDelete(draft.id);
+    } catch (error) {
+      setFeedback({ tone: "error", text: getErrorMessage(error) });
+    }
+  };
+
+  return (
+    <div className={MEMO_BACKDROP} role="presentation" onClick={onClose}>
+      <div className={MEMO_MODAL} role="dialog" aria-modal="true" aria-label={draft.id ? "Edit memorable day" : "Add memorable day"} onClick={(event) => event.stopPropagation()}>
+        <SectionHead title={draft.id ? "Edit memorable day" : "Add memorable day"} variant="dashboard" />
+        {feedback?.tone === "error" ? <InlineFeedback message={feedback} /> : null}
+        <div className="grid grid-cols-[168px_88px] gap-3 items-start justify-start">
+          <label className="grid gap-2 content-start min-w-0">
+            <span className={FIELD_LINE_LABEL}>Date</span>
+            <DateInput value={draft.date} onChange={(value) => setDraft((current) => ({ ...current, date: value }))} ariaLabel="Date" />
+          </label>
+          <label className="grid gap-2 content-start w-[88px] min-w-[88px] justify-self-end self-start">
+            <span className={FIELD_LINE_LABEL}>Emoji</span>
+            <div ref={emojiPickerRef} className="relative w-full min-w-0">
+              <button
+                type="button"
+                className={EMOJI_TRIGGER}
+                aria-label={`Emoji ${draft.emoji || "✨"}`}
+                aria-haspopup="dialog"
+                aria-expanded={emojiPickerOpen}
+                aria-controls="emoji-picker-panel"
+                onClick={() => { if (emojiPickerOpen) { closeEmojiPicker(); return; } openEmojiPicker(); }}
+              >
+                <span aria-hidden="true" className="text-[32px] leading-none">{draft.emoji || "✨"}</span>
+              </button>
+
+              {emojiPickerOpen ? (
+                <div
+                  id="emoji-picker-panel"
+                  role="dialog"
+                  aria-label="Emoji picker"
+                  className="absolute top-full mt-2 right-0 w-[min(420px,calc(100vw-32px))] max-w-[min(420px,calc(100vw-32px))] max-h-[min(520px,calc(100vh-180px))] flex flex-col gap-3 p-3 bg-card border border-border rounded-md shadow-[var(--shadow)] z-30"
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  <label className="grid gap-2 content-start m-0">
+                    <span className={`${FIELD_LINE_LABEL} pt-0 pb-0`}>Search emoji</span>
+                    <input
+                      ref={emojiPickerSearchRef}
+                      id="emoji-search"
+                      name="emoji-search"
+                      className="w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft"
+                      type="search"
+                      value={emojiPickerSearch}
+                      onChange={(event) => setEmojiPicker((current) => ({ ...current, search: event.target.value }))}
+                      placeholder="Search emoji"
+                    />
+                  </label>
+
+                  <div role="tablist" aria-label="Emoji categories" className="flex flex-wrap gap-2">
+                    {emojiCategoryOrder.map((category) => {
+                      const isActive = emojiPickerActiveCategory === category;
+                      const label = emojiCategoryLabels[category];
+                      return (
+                        <button
+                          key={category}
+                          type="button"
+                          role="tab"
+                          aria-selected={isActive}
+                          className={`${EMOJI_TAB} ${isActive ? "text-accent" : "text-muted hover:text-text"}`}
+                          onClick={() => {
+                            rememberEmojiPickerScrollTop();
+                            setEmojiPicker((current) => ({ ...current, activeCategory: category }));
+                          }}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div
+                    ref={emojiPickerScrollRef}
+                    className="min-h-0 max-h-[320px] overflow-auto [overscroll-behavior:contain] [scrollbar-width:thin] [scrollbar-gutter:stable] pr-[2px] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent]"
+                  >
+                    {emojiPickerRecords.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {emojiPickerRecords.map((record) => {
+                          const isSelected = draft.emoji === record.emoji;
+                          return (
+                            <button
+                              key={record.emoji}
+                              type="button"
+                              aria-label={record.name}
+                              aria-pressed={isSelected}
+                              className={`${EMOJI_BTN} ${isSelected ? "text-text" : ""}`}
+                              onClick={() => selectEmoji(record)}
+                            >
+                              {record.emoji}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <p className="m-0 px-[2px] pt-2 pb-[2px] text-center text-muted-soft text-control">No emoji match.</p>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </label>
+        </div>
+        <FieldLine
+          label="Title"
+          type="text"
+          value={draft.title}
+          onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
+        />
+        <FieldLine
+          label="Description"
+          multiline
+          compact
+          rows={3}
+          value={draft.description}
+          onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))}
+        />
+        <div className="grid gap-2 content-start">
+          <span className={FIELD_LINE_LABEL}>Repeat</span>
+          <Select
+            ariaLabel="Repeat"
+            value={draft.repeatMode}
+            onValueChange={(value) => {
+              const option = REPEAT_OPTIONS.find((item) => item.value === value);
+              if (option) setDraft((current) => ({ ...current, repeatMode: option.value }));
+            }}
+            options={REPEAT_OPTIONS}
+            disabled={draft.locked}
+          />
+        </div>
+        {draft.locked ? <p className="text-muted text-control">Edit birthday in Settings. Same truth, less duplication.</p> : null}
+        <div className={MEMO_MODAL_ACTIONS}>
+          <Button variant="primary" onClick={() => void handleSave()} disabled={isSaving || draft.locked}>
+            Save
+          </Button>
+          {draft.id && !draft.locked ? (
+            <Button variant="danger" onClick={() => void handleDelete()} disabled={isSaving}>
+              Delete
+            </Button>
+          ) : null}
+          <button type="button" className={buttonClass("default", "md", "!bg-[color-mix(in_srgb,var(--text)_10%,transparent)] hover:!bg-[color-mix(in_srgb,var(--text)_16%,transparent)]")} onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/memorable-days-constants.ts
+++ b/frontend/src/app/memorable-days-constants.ts
@@ -1,0 +1,12 @@
+export const MEMO_BACKDROP =
+  "fixed inset-0 bg-scrim [backdrop-filter:blur(6px)] grid place-items-center p-5 z-40";
+export const MEMO_MODAL = "w-[min(520px,100%)] p-5 flex flex-col gap-3 bg-card border-0 rounded-md shadow-none";
+export const MEMO_DAY_CELL =
+  "min-h-[108px] p-3 rounded-md bg-card-soft text-text text-left flex flex-col gap-2 relative transition-[background,color] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
+export const MEMO_LIST_ITEM =
+  "flex items-center justify-between flex-[0_0_auto] w-full gap-3 p-3 rounded-md border-0 bg-card-soft text-text shadow-none hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
+export const MEMO_MODAL_ACTIONS = "flex items-center gap-3 justify-end flex-wrap";
+export const DAY_NUMBER =
+  "bg-transparent border-0 shadow-none min-h-0 p-0 font-[inherit] text-[inherit] cursor-pointer leading-none";
+export const EMOJI_TRIGGER =
+  "min-w-0 min-h-0 p-0 rounded-none inline-flex items-center justify-center bg-transparent border border-transparent text-text shadow-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";

--- a/frontend/src/app/memorable-days-constants.ts
+++ b/frontend/src/app/memorable-days-constants.ts
@@ -10,3 +10,9 @@ export const DAY_NUMBER =
   "bg-transparent border-0 shadow-none min-h-0 p-0 font-[inherit] text-[inherit] cursor-pointer leading-none";
 export const EMOJI_TRIGGER =
   "min-w-0 min-h-0 p-0 rounded-none inline-flex items-center justify-center bg-transparent border border-transparent text-text shadow-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
+
+export const REPEAT_OPTIONS: { value: "one-time" | "monthly" | "yearly"; label: string }[] = [
+  { value: "one-time", label: "One-time" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];

--- a/frontend/src/app/memorable-days.tsx
+++ b/frontend/src/app/memorable-days.tsx
@@ -1,46 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { z } from "zod";
-import { SectionHead, InlineFeedback, useSplitColumnHeightSync } from "./shared";
-import { MS_PER_DAY, toDateKey, type InlineMessage, type MemorableDay } from "./core";
-import { emojiCatalog, emojiCategoryLabels, type EmojiCategory, type EmojiRecord } from "./emoji-catalog";
-import { getErrorMessage } from "../lib";
-import { memorableDayPayloadSchema, matchesMemorableDate, type useMemorableDays } from "../hooks/use-memorable-days";
-import { DateInput } from "../components/ui/DateInput";
-import { Select } from "../components/ui/select";
+import { SectionHead, useSplitColumnHeightSync } from "./shared";
+import { MS_PER_DAY, toDateKey, type MemorableDay } from "./core";
+import { matchesMemorableDate, type useMemorableDays } from "../hooks/use-memorable-days";
 import { Button, buttonClass } from "../components/ui/Button";
-import { FieldLine, FIELD_LINE_LABEL } from "../components/ui/FieldLine";
 import { EntriesHeading } from "./entries";
+import { MemorableDayModal, type DraftState } from "./memorable-day-modal";
+import {
+  MEMO_BACKDROP,
+  MEMO_MODAL,
+  MEMO_DAY_CELL,
+  MEMO_LIST_ITEM,
+  MEMO_MODAL_ACTIONS,
+  DAY_NUMBER,
+} from "./memorable-days-constants";
 
-const MEMO_BACKDROP =
-  "fixed inset-0 bg-scrim [backdrop-filter:blur(6px)] grid place-items-center p-5 z-40";
-const MEMO_MODAL = "w-[min(520px,100%)] p-5 flex flex-col gap-3 bg-card border-0 rounded-md shadow-none";
-export const MEMO_DAY_CELL =
-  "min-h-[108px] p-3 rounded-md bg-card-soft text-text text-left flex flex-col gap-2 relative transition-[background,color] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
-export const MEMO_LIST_ITEM =
-  "flex items-center justify-between flex-[0_0_auto] w-full gap-3 p-3 rounded-md border-0 bg-card-soft text-text shadow-none hover:bg-[color-mix(in_srgb,var(--text)_4%,var(--card-soft))]";
-const MEMO_MODAL_ACTIONS = "flex items-center gap-3 justify-end flex-wrap";
-const EMOJI_TAB =
-  "min-h-0 px-[4px] py-0 rounded-none border border-transparent bg-transparent shadow-none text-micro font-bold tracking-[0.08em] uppercase cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
-const EMOJI_BTN =
-  "min-h-0 p-[2px] rounded-none border border-transparent bg-transparent shadow-none inline-flex items-center justify-center text-title leading-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
-// Exported so the Design System demo reuses the exact production contracts.
-export const DAY_NUMBER =
-  "bg-transparent border-0 shadow-none min-h-0 p-0 font-[inherit] text-[inherit] cursor-pointer leading-none";
-export const EMOJI_TRIGGER =
-  "min-w-0 min-h-0 p-0 rounded-none inline-flex items-center justify-center bg-transparent border border-transparent text-text shadow-none cursor-pointer focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_var(--ring)]";
+export { MEMO_DAY_CELL, MEMO_LIST_ITEM, DAY_NUMBER, EMOJI_TRIGGER } from "./memorable-days-constants";
 
 type Props = {
   memorable: ReturnType<typeof useMemorableDays>;
-};
-
-type DraftState = {
-  id: number | null;
-  date: string;
-  title: string;
-  emoji: string;
-  description: string;
-  repeatMode: "one-time" | "monthly" | "yearly";
-  locked: boolean;
 };
 
 type MemorableLookups = {
@@ -48,48 +25,6 @@ type MemorableLookups = {
   monthlyByDay: Map<number, MemorableDay[]>;
   yearlyByMonthDay: Map<string, MemorableDay[]>;
 };
-
-type EmojiPickerScrollTopByCategory = Record<EmojiCategory, number>;
-
-type EmojiPickerState = {
-  open: boolean;
-  activeCategory: EmojiCategory;
-  search: string;
-  recent: string[];
-  scrollTopByCategory: EmojiPickerScrollTopByCategory;
-};
-
-const emojiCategoryOrder = Object.keys(emojiCategoryLabels) as EmojiCategory[];
-
-const REPEAT_OPTIONS: { value: DraftState["repeatMode"]; label: string }[] = [
-  { value: "one-time", label: "One-time" },
-  { value: "monthly", label: "Monthly" },
-  { value: "yearly", label: "Yearly" },
-];
-
-function createEmojiPickerScrollTopByCategory(): EmojiPickerScrollTopByCategory {
-  return {
-    recent: 0,
-    smileys: 0,
-    people: 0,
-    nature: 0,
-    food: 0,
-    travel: 0,
-    objects: 0,
-    symbols: 0,
-    flags: 0,
-  };
-}
-
-function createEmojiPickerState(): EmojiPickerState {
-  return {
-    open: false,
-    activeCategory: "recent",
-    search: "",
-    recent: [],
-    scrollTopByCategory: createEmojiPickerScrollTopByCategory(),
-  };
-}
 
 function buildCalendarDays(month: Date, weekStart: "sunday" | "monday") {
   const firstDay = new Date(month.getFullYear(), month.getMonth(), 1);
@@ -110,17 +45,6 @@ function buildCalendarDays(month: Date, weekStart: "sunday" | "monday") {
 
 function emptyDraft(date: string): DraftState {
   return { id: null, date, title: "", emoji: "", description: "", repeatMode: "one-time", locked: false };
-}
-
-function getDraftErrorMessage(error: unknown) {
-  if (error instanceof z.ZodError) {
-    const titleIssue = error.issues.find((issue) => issue.path[0] === "title");
-    if (titleIssue) return "Title is required.";
-    const dateIssue = error.issues.find((issue) => issue.path[0] === "date");
-    if (dateIssue) return "Date is invalid.";
-    return "Check the form fields and try again.";
-  }
-  return getErrorMessage(error);
 }
 
 function buildMemorableLookups(items: MemorableDay[]): MemorableLookups {
@@ -145,47 +69,17 @@ function buildMemorableLookups(items: MemorableDay[]): MemorableLookups {
   return { oneTimeByDate, monthlyByDay, yearlyByMonthDay };
 }
 
-const emojiByValue = new Map(emojiCatalog.map((record) => [record.emoji, record]));
-const emojiRecordsByCategory = (() => {
-  const grouped = {
-    smileys: [] as EmojiRecord[],
-    people: [] as EmojiRecord[],
-    nature: [] as EmojiRecord[],
-    food: [] as EmojiRecord[],
-    travel: [] as EmojiRecord[],
-    objects: [] as EmojiRecord[],
-    symbols: [] as EmojiRecord[],
-    flags: [] as EmojiRecord[],
-  };
-  for (const record of emojiCatalog) {
-    grouped[record.category].push(record);
-  }
-  return grouped;
-})();
-
 export function MemorableDaysSection({ memorable }: Props) {
   const [draft, setDraft] = useState<DraftState | null>(null);
-  const [feedback, setFeedback] = useState<InlineMessage | null>(null);
   const [successDateKey, setSuccessDateKey] = useState<string | null>(null);
   const [popoverDateKey, setPopoverDateKey] = useState<string | null>(null);
-  const [emojiPicker, setEmojiPicker] = useState<EmojiPickerState>(() => createEmojiPickerState());
   const popoverRef = useRef<HTMLDivElement | null>(null);
-  const emojiPickerRef = useRef<HTMLDivElement | null>(null);
-  const emojiPickerScrollRef = useRef<HTMLDivElement | null>(null);
-  const emojiPickerSearchRef = useRef<HTMLInputElement | null>(null);
-  const emojiPickerWasOpenRef = useRef(false);
+
   const weekdayLabels = memorable.weekStart === "monday"
     ? ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const days = useMemo(() => buildCalendarDays(memorable.visibleMonth, memorable.weekStart), [memorable.visibleMonth, memorable.weekStart]);
   const lookups = useMemo(() => buildMemorableLookups(memorable.memorableDays), [memorable.memorableDays]);
-  const {
-    open: emojiPickerOpen,
-    activeCategory: emojiPickerActiveCategory,
-    search: emojiPickerSearch,
-    recent: emojiPickerRecent,
-    scrollTopByCategory: emojiPickerScrollTopByCategory,
-  } = emojiPicker;
   const todayKey = toDateKey(new Date());
   const { leftColRef, rightColRef } = useSplitColumnHeightSync([days.length, memorable.memorableDays.length, memorable.isLoading]);
   const popoverItems = useMemo(() => {
@@ -198,28 +92,6 @@ export function MemorableDaysSection({ memorable }: Props) {
       ...(lookups.yearlyByMonthDay.get(monthDayKey) ?? []),
     ].filter((item) => matchesMemorableDate(item, popoverDateKey));
   }, [popoverDateKey, lookups]);
-  const emojiPickerRecords = useMemo(() => {
-    const search = emojiPickerSearch.trim().toLowerCase();
-    if (search) {
-      // When searching, search the full catalog instead of just the active category
-      return emojiCatalog.filter((record) => record.searchText.includes(search));
-    }
-    const baseRecords = emojiPickerActiveCategory === "recent"
-      ? emojiPickerRecent.map((emoji) => emojiByValue.get(emoji)).filter((record): record is EmojiRecord => Boolean(record))
-      : emojiRecordsByCategory[emojiPickerActiveCategory];
-    return baseRecords;
-  }, [emojiPickerActiveCategory, emojiPickerRecent, emojiPickerSearch]);
-
-  useEffect(() => {
-    if (!draft) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !emojiPickerOpen) {
-        setDraft(null);
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [draft, emojiPickerOpen]);
 
   useEffect(() => {
     if (!successDateKey) return;
@@ -244,122 +116,16 @@ export function MemorableDaysSection({ memorable }: Props) {
     };
   }, [popoverDateKey]);
 
-  useEffect(() => {
-    if (!emojiPickerOpen) return;
-    const savedScrollTop = emojiPickerScrollTopByCategory[emojiPickerActiveCategory] ?? 0;
-    const wasOpen = emojiPickerWasOpenRef.current;
-    emojiPickerWasOpenRef.current = true;
-    const frame = window.requestAnimationFrame(() => {
-      if (!wasOpen && emojiPickerSearchRef.current) {
-        emojiPickerSearchRef.current.focus();
-      }
-      if (emojiPickerScrollRef.current) {
-        emojiPickerScrollRef.current.scrollTop = savedScrollTop;
-      }
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [emojiPickerActiveCategory, emojiPickerOpen, emojiPickerScrollTopByCategory]);
-
-  useEffect(() => {
-    if (emojiPickerOpen) return;
-    emojiPickerWasOpenRef.current = false;
-  }, [emojiPickerOpen]);
-
-  const rememberEmojiPickerScrollTop = useCallback(() => {
-    const scroller = emojiPickerScrollRef.current;
-    if (!scroller) return;
-    const nextScrollTop = scroller.scrollTop;
-    setEmojiPicker((current) => {
-      const currentScrollTop = current.scrollTopByCategory[current.activeCategory] ?? 0;
-      if (currentScrollTop === nextScrollTop) return current;
-      return {
-        ...current,
-        scrollTopByCategory: {
-          ...current.scrollTopByCategory,
-          [current.activeCategory]: nextScrollTop,
-        },
-      };
-    });
-  }, []);
-
-  const closeEmojiPicker = useCallback(() => {
-    rememberEmojiPickerScrollTop();
-    setEmojiPicker((current) => ({ ...current, open: false }));
-  }, [rememberEmojiPickerScrollTop]);
-
-  useEffect(() => {
-    if (!emojiPickerOpen) return;
-    const onMouseDown = (event: MouseEvent) => {
-      if (emojiPickerRef.current?.contains(event.target as Node)) return;
-      closeEmojiPicker();
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeEmojiPicker();
-      }
-    };
-    window.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("keydown", onKeyDown);
-    return () => {
-      window.removeEventListener("mousedown", onMouseDown);
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [closeEmojiPicker, emojiPickerOpen]);
-
-  useEffect(() => {
-    if (!draft?.date) return;
-    const [year, month] = draft.date.split("-").map(Number);
-    if (!year || !month) return;
-    memorable.setVisibleMonth(new Date(year, month - 1, 1));
-  }, [draft?.date, memorable]);
-
-  const closeDraft = () => {
-    setDraft(null);
-    setFeedback(null);
-    closeEmojiPicker();
-  };
-
-  const onSave = async () => {
-    if (!draft) return;
-    try {
-      const payload = memorableDayPayloadSchema.parse({
-        date: draft.date,
-        title: draft.title,
-        emoji: draft.emoji,
-        description: draft.description,
-        repeatMode: draft.repeatMode,
-      });
-      if (draft.id) await memorable.updateMemorableDay(draft.id, payload);
-      else await memorable.createMemorableDay(payload);
-      setSuccessDateKey(draft.date);
-      closeDraft();
-    } catch (error) {
-      setFeedback({ tone: "error", text: getDraftErrorMessage(error) });
-    }
-  };
-
-  const onDelete = async () => {
-    if (!draft?.id) return;
-    try {
-      await memorable.deleteMemorableDay(draft.id);
-      closeDraft();
-    } catch (error) {
-      setFeedback({ tone: "error", text: getErrorMessage(error) });
-    }
-  };
+  const closeDraft = useCallback(() => setDraft(null), []);
 
   const openCreate = (date: string) => {
     memorable.setSelectedDate(date);
-    setFeedback(null);
-    closeEmojiPicker();
     setDraft(emptyDraft(date));
   };
 
   const openEdit = (item: MemorableDay) => {
     memorable.setSelectedDate(item.date);
     memorable.setVisibleMonth(new Date(`${item.date}T00:00:00`));
-    setFeedback(null);
-    closeEmojiPicker();
     setDraft({
       id: item.id > 0 ? item.id : null,
       date: item.date,
@@ -371,19 +137,30 @@ export function MemorableDaysSection({ memorable }: Props) {
     });
   };
 
-  const openEmojiPicker = () => {
-    setEmojiPicker((current) => ({ ...current, open: true }));
-    emojiPickerWasOpenRef.current = false;
-  };
+  const handleSave = useCallback(async (savedDraft: DraftState) => {
+    const payload = {
+      date: savedDraft.date,
+      title: savedDraft.title,
+      emoji: savedDraft.emoji,
+      description: savedDraft.description,
+      repeatMode: savedDraft.repeatMode,
+    };
+    if (savedDraft.id) await memorable.updateMemorableDay(savedDraft.id, payload);
+    else await memorable.createMemorableDay(payload);
+    setSuccessDateKey(savedDraft.date);
+    closeDraft();
+  }, [memorable, closeDraft]);
 
-  const selectEmoji = (record: EmojiRecord) => {
-    setDraft((current) => (current ? { ...current, emoji: record.emoji } : current));
-    setEmojiPicker((current) => ({
-      ...current,
-      recent: [record.emoji, ...current.recent.filter((emoji) => emoji !== record.emoji)].slice(0, 24),
-    }));
-    closeEmojiPicker();
-  };
+  const handleDelete = useCallback(async (id: number) => {
+    await memorable.deleteMemorableDay(id);
+    closeDraft();
+  }, [memorable, closeDraft]);
+
+  const handleDraftDateChange = useCallback((date: string) => {
+    const [year, month] = date.split("-").map(Number);
+    if (!year || !month) return;
+    memorable.setVisibleMonth(new Date(year, month - 1, 1));
+  }, [memorable]);
 
   const onListItemWheel = (event: React.WheelEvent<HTMLButtonElement>) => {
     const list = event.currentTarget.closest(".memorable-list");
@@ -405,7 +182,6 @@ export function MemorableDaysSection({ memorable }: Props) {
         </div>
       </div>
       <Button variant="primary" className="absolute top-8 right-2" onClick={() => openCreate(toDateKey(new Date()))}>Add new</Button>
-      {feedback?.tone === "error" ? <InlineFeedback message={feedback} /> : null}
 
       <div className="grid gap-12 items-start grid-cols-[minmax(0,1.55fr)_minmax(280px,0.9fr)] max-xwide:grid-cols-1 max-xwide:gap-0">
         <section ref={leftColRef} className="min-w-0 p-0 max-xwide:border-b max-xwide:border-border max-xwide:pb-8">
@@ -432,6 +208,7 @@ export function MemorableDaysSection({ memorable }: Props) {
               const dayKey = toDateKey(day);
               const monthMatch = day.getMonth() === memorable.visibleMonth.getMonth();
               const isToday = dayKey === todayKey;
+              const isSuccess = dayKey === successDateKey;
               const monthDayKey = dayKey.slice(5);
               const items = [
                 ...(lookups.oneTimeByDate.get(dayKey) ?? []),
@@ -441,7 +218,7 @@ export function MemorableDaysSection({ memorable }: Props) {
               return (
                 <div
                   key={dayKey}
-                  className={`${MEMO_DAY_CELL}${monthMatch ? "" : " opacity-[0.48]"}${isToday ? " shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_28%,transparent)]" : ""}`}
+                  className={`${MEMO_DAY_CELL}${monthMatch ? "" : " opacity-[0.48]"}${isToday ? " shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_28%,transparent)]" : ""}${isSuccess ? " shadow-[0_0_0_2px_var(--success)]" : ""}`}
                   onClick={(event) => {
                     if ((event.target as Element).closest("button")) return;
                     memorable.setSelectedDate(dayKey);
@@ -506,164 +283,21 @@ export function MemorableDaysSection({ memorable }: Props) {
                     <span className="text-micro text-muted-soft">{item.locked ? "Locked from Settings" : item.repeatMode}</span>
                   </span>
                 </button>
-                ))}
+              ))}
             </div>
           )}
         </section>
       </div>
 
       {draft ? (
-        <div className={MEMO_BACKDROP} role="presentation" onClick={closeDraft}>
-          <div className={MEMO_MODAL} role="dialog" aria-modal="true" aria-label={draft.id ? "Edit memorable day" : "Add memorable day"} onClick={(event) => event.stopPropagation()}>
-            <SectionHead title={draft.id ? "Edit memorable day" : "Add memorable day"} variant="dashboard" />
-            <div className="grid grid-cols-[168px_88px] gap-3 items-start justify-start">
-              <label className="grid gap-2 content-start min-w-0">
-                <span className={FIELD_LINE_LABEL}>Date</span>
-                <DateInput value={draft.date} onChange={(value) => setDraft((current) => current ? { ...current, date: value } : current)} ariaLabel="Date" />
-              </label>
-              <label className="grid gap-2 content-start w-[88px] min-w-[88px] justify-self-end self-start">
-                <span className={FIELD_LINE_LABEL}>Emoji</span>
-                <div ref={emojiPickerRef} className="relative w-full min-w-0">
-                  <button
-                    type="button"
-                    className={EMOJI_TRIGGER}
-                    aria-label={`Emoji ${draft.emoji || "✨"}`}
-                    aria-haspopup="dialog"
-                    aria-expanded={emojiPickerOpen}
-                    aria-controls="emoji-picker-panel"
-                    onClick={() => {
-                      if (emojiPickerOpen) {
-                        closeEmojiPicker();
-                        return;
-                      }
-                      openEmojiPicker();
-                    }}
-                  >
-                    <span aria-hidden="true" className="text-[32px] leading-none">
-                      {draft.emoji || "✨"}
-                    </span>
-                  </button>
-
-                  {emojiPickerOpen ? (
-                    <div
-                      id="emoji-picker-panel"
-                      role="dialog"
-                      aria-label="Emoji picker"
-                      className="absolute top-full mt-2 right-0 w-[min(420px,calc(100vw-32px))] max-w-[min(420px,calc(100vw-32px))] max-h-[min(520px,calc(100vh-180px))] flex flex-col gap-3 p-3 bg-card border border-border rounded-md shadow-[var(--shadow)] z-30"
-                      onMouseDown={(event) => event.stopPropagation()}
-                    >
-                      <label className="grid gap-2 content-start m-0">
-                        <span className={`${FIELD_LINE_LABEL} pt-0 pb-0`}>Search emoji</span>
-                        <input
-                          ref={emojiPickerSearchRef}
-                          id="emoji-search"
-                          name="emoji-search"
-                          className="w-full bg-[color-mix(in_srgb,white_3%,var(--bg))] border-0 rounded-sm px-3 py-2 text-text text-control font-medium font-body shadow-none outline-none transition-[background,box-shadow] duration-150 ease-[ease] hover:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:bg-[color-mix(in_srgb,white_5%,var(--bg))] focus:shadow-[inset_0_0_0_1px_var(--accent)] placeholder:text-muted-soft [[data-theme=oled]_&]:bg-card-soft"
-                          type="search"
-                          value={emojiPickerSearch}
-                          onChange={(event) => setEmojiPicker((current) => ({ ...current, search: event.target.value }))}
-                          placeholder="Search emoji"
-                        />
-                      </label>
-
-                      <div role="tablist" aria-label="Emoji categories" className="flex flex-wrap gap-2">
-                        {emojiCategoryOrder.map((category) => {
-                          const isActive = emojiPickerActiveCategory === category;
-                          const label = emojiCategoryLabels[category];
-                          return (
-                            <button
-                              key={category}
-                              type="button"
-                              role="tab"
-                              aria-selected={isActive}
-                              className={`${EMOJI_TAB} ${isActive ? "text-accent" : "text-muted hover:text-text"}`}
-                              onClick={() => {
-                                rememberEmojiPickerScrollTop();
-                                setEmojiPicker((current) => ({ ...current, activeCategory: category }));
-                              }}
-                            >
-                              {label}
-                            </button>
-                          );
-                        })}
-                      </div>
-
-                      <div
-                        ref={emojiPickerScrollRef}
-                        className="min-h-0 max-h-[320px] overflow-auto [overscroll-behavior:contain] [scrollbar-width:thin] [scrollbar-gutter:stable] pr-[2px] [scrollbar-color:transparent_transparent] hover:[scrollbar-color:rgba(255,255,255,0.18)_transparent] focus-within:[scrollbar-color:rgba(255,255,255,0.18)_transparent]"
-                      >
-                        {emojiPickerRecords.length > 0 ? (
-                          <div className="flex flex-wrap gap-2">
-                            {emojiPickerRecords.map((record) => {
-                              const isSelected = draft.emoji === record.emoji;
-                              return (
-                                <button
-                                  key={record.emoji}
-                                  type="button"
-                                  aria-label={record.name}
-                                  aria-pressed={isSelected}
-                                  className={`${EMOJI_BTN} ${isSelected ? "text-text" : ""}`}
-                                  onClick={() => selectEmoji(record)}
-                                >
-                                  {record.emoji}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        ) : (
-                          <p className="m-0 px-[2px] pt-2 pb-[2px] text-center text-muted-soft text-control">
-                            No emoji match.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  ) : null}
-                </div>
-              </label>
-            </div>
-            <FieldLine
-              label="Title"
-              type="text"
-              value={draft.title}
-              onChange={(event) => setDraft((current) => current ? { ...current, title: event.target.value } : current)}
-            />
-            <FieldLine
-              label="Description"
-              multiline
-              compact
-              rows={3}
-              value={draft.description}
-              onChange={(event) => setDraft((current) => current ? { ...current, description: event.target.value } : current)}
-            />
-            <div className="grid gap-2 content-start">
-              <span className={FIELD_LINE_LABEL}>Repeat</span>
-              <Select
-                ariaLabel="Repeat"
-                value={draft.repeatMode}
-                onValueChange={(value) => {
-                  const option = REPEAT_OPTIONS.find((item) => item.value === value);
-                  if (option) setDraft((current) => current ? { ...current, repeatMode: option.value } : current);
-                }}
-                options={REPEAT_OPTIONS}
-                disabled={draft.locked}
-              />
-            </div>
-            {draft.locked ? <p className="text-muted text-control">Edit birthday in Settings. Same truth, less duplication.</p> : null}
-            <div className={MEMO_MODAL_ACTIONS}>
-              <Button variant="primary" onClick={() => void onSave()} disabled={memorable.isSaving || draft.locked}>
-                Save
-              </Button>
-              {draft.id && !draft.locked ? (
-                <Button variant="danger" onClick={() => void onDelete()} disabled={memorable.isSaving}>
-                  Delete
-                </Button>
-              ) : null}
-              <button type="button" className={buttonClass("default", "md", "!bg-[color-mix(in_srgb,var(--text)_10%,transparent)] hover:!bg-[color-mix(in_srgb,var(--text)_16%,transparent)]")} onClick={closeDraft}>
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
+        <MemorableDayModal
+          initialDraft={draft}
+          isSaving={memorable.isSaving}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          onClose={closeDraft}
+          onDraftDateChange={handleDraftDateChange}
+        />
       ) : null}
 
       {popoverDateKey ? (

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -437,15 +437,12 @@ export function useDashboard(enabled: boolean) {
     });
   };
 
-  // Global streak: use unfiltered data when a range is active; fall back to range data while loading
-  const streakDiary = dashboardFrom ? (allDiaryQuery.data ?? diaryQuery.data ?? []) : (diaryQuery.data ?? []);
-  const streakPain = dashboardFrom ? (allPainQuery.data ?? painQuery.data ?? []) : (painQuery.data ?? []);
-  const globalDays = useMemo(
-    () => buildDashboardDays(streakDiary, streakPain),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [streakDiary, streakPain],
-  );
-  const globalStreak = useMemo(() => getLongestEntryStreak(globalDays), [globalDays]);
+  // Global (all-time) streak: use unfiltered data when range is active, else main query data.
+  const globalStreak = useMemo(() => {
+    const streakDiary = dashboardFrom ? (allDiaryQuery.data ?? diaryQuery.data ?? []) : (diaryQuery.data ?? []);
+    const streakPain = dashboardFrom ? (allPainQuery.data ?? painQuery.data ?? []) : (painQuery.data ?? []);
+    return getLongestEntryStreak(buildDashboardDays(streakDiary, streakPain));
+  }, [dashboardFrom, allDiaryQuery.data, diaryQuery.data, allPainQuery.data, painQuery.data]);
 
   const dashboardInsights = useMemo(
     () => buildInsightRail(dashboardDays, dashboardCards, globalStreak),

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -130,15 +130,14 @@ function describeMissingData(days: DashboardDay[]) {
   return `Diary missing on ${missingDiary} tracked day${missingDiary === 1 ? "" : "s"}.`;
 }
 
-function buildInsightRail(days: DashboardDay[], cards: DashboardCard[]): DashboardInsight[] {
-  const streak = getLongestEntryStreak(days);
+function buildInsightRail(days: DashboardDay[], cards: DashboardCard[], globalStreak: number): DashboardInsight[] {
   return [
     {
       title: "Best streak",
       detail:
-        streak === 0
-          ? "No tracked days in this range yet."
-          : `${streak} day${streak === 1 ? "" : "s"} with at least one diary or pain entry.`,
+        globalStreak === 0
+          ? "No tracked days yet."
+          : `${globalStreak} day${globalStreak === 1 ? "" : "s"} with at least one diary or pain entry.`,
     },
     {
       title: "Biggest shift",
@@ -243,22 +242,46 @@ export function useDashboard(enabled: boolean) {
     return () => observer.disconnect();
   }, []);
 
-  const diaryQuery = useQuery({
-    queryKey: ["diary"],
-    enabled,
-    queryFn: async () => apiFetch("/api/v1/diary", { method: "GET" }, (raw) => diaryListSchema.parse(raw).data),
-  });
-
-  const painQuery = useQuery({
-    queryKey: ["pain"],
-    enabled,
-    queryFn: async () => apiFetch("/api/v1/pain", { method: "GET" }, (raw) => painListSchema.parse(raw).data),
-  });
-
   const restoredRange = normalizeQuickRange(prefsQuery.data?.lastRange);
   const restoredBounds = getQuickRangeBounds(restoredRange);
   const dashboardFrom = dashboardBoundsOverride?.from ?? restoredBounds.from;
   const dashboardTo = dashboardBoundsOverride?.to ?? restoredBounds.to;
+
+  // Extend range to cover the previous period too (needed for comparison cards)
+  const extFrom = dashboardFrom
+    ? (previousRange(dashboardFrom, dashboardTo)?.from ?? dashboardFrom)
+    : "";
+
+  const diaryQuery = useQuery({
+    queryKey: ["diary", extFrom || null, dashboardTo || null],
+    enabled,
+    queryFn: async () => {
+      const qs = extFrom ? `?from=${extFrom}&to=${dashboardTo}` : "";
+      return apiFetch(`/api/v1/diary${qs}`, { method: "GET" }, (raw) => diaryListSchema.parse(raw).data);
+    },
+  });
+
+  const painQuery = useQuery({
+    queryKey: ["pain", extFrom || null, dashboardTo || null],
+    enabled,
+    queryFn: async () => {
+      const qs = extFrom ? `?from=${extFrom}&to=${dashboardTo}` : "";
+      return apiFetch(`/api/v1/pain${qs}`, { method: "GET" }, (raw) => painListSchema.parse(raw).data);
+    },
+  });
+
+  // Unfiltered queries for global (all-time) streak — only enabled when a date range is active.
+  // When range is "all", the main queries already fetch all data.
+  const allDiaryQuery = useQuery({
+    queryKey: ["diary-all"],
+    enabled: enabled && Boolean(dashboardFrom),
+    queryFn: async () => apiFetch("/api/v1/diary", { method: "GET" }, (raw) => diaryListSchema.parse(raw).data),
+  });
+  const allPainQuery = useQuery({
+    queryKey: ["pain-all"],
+    enabled: enabled && Boolean(dashboardFrom),
+    queryFn: async () => apiFetch("/api/v1/pain", { method: "GET" }, (raw) => painListSchema.parse(raw).data),
+  });
   const activeQuickRange = activeQuickRangeOverride ?? restoredRange;
   const graphSelection = graphSelectionOverride ?? extractWellbeingSelection(prefsQuery.data?.graphSelection);
 
@@ -288,7 +311,13 @@ export function useDashboard(enabled: boolean) {
     [painQuery.data, dashboardFrom, dashboardTo],
   );
 
-  const hasEntriesOverall = (diaryQuery.data?.length ?? 0) > 0 || (painQuery.data?.length ?? 0) > 0;
+  // Include all-data queries for hasEntriesOverall so "no entries" empty state
+  // is not shown when a date range is active but historical data exists.
+  const hasEntriesOverall =
+    (diaryQuery.data?.length ?? 0) > 0 ||
+    (painQuery.data?.length ?? 0) > 0 ||
+    (allDiaryQuery.data?.length ?? 0) > 0 ||
+    (allPainQuery.data?.length ?? 0) > 0;
   const hasEntriesInRange = filteredDiary.length > 0 || filteredPain.length > 0;
   const dashboardDays = useMemo(
     () => buildDashboardDays(filteredDiary, filteredPain),
@@ -408,9 +437,19 @@ export function useDashboard(enabled: boolean) {
     });
   };
 
+  // Global streak: use unfiltered data when a range is active; fall back to range data while loading
+  const streakDiary = dashboardFrom ? (allDiaryQuery.data ?? diaryQuery.data ?? []) : (diaryQuery.data ?? []);
+  const streakPain = dashboardFrom ? (allPainQuery.data ?? painQuery.data ?? []) : (painQuery.data ?? []);
+  const globalDays = useMemo(
+    () => buildDashboardDays(streakDiary, streakPain),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [streakDiary, streakPain],
+  );
+  const globalStreak = useMemo(() => getLongestEntryStreak(globalDays), [globalDays]);
+
   const dashboardInsights = useMemo(
-    () => buildInsightRail(dashboardDays, dashboardCards),
-    [dashboardDays, dashboardCards],
+    () => buildInsightRail(dashboardDays, dashboardCards, globalStreak),
+    [dashboardDays, dashboardCards, globalStreak],
   );
 
   const dashboardConnections = useMemo(
@@ -422,7 +461,7 @@ export function useDashboard(enabled: boolean) {
     dashboardFrom,
     dashboardTo,
     activeQuickRange,
-    isLoading: diaryQuery.isLoading || painQuery.isLoading,
+    isLoading: diaryQuery.isLoading || painQuery.isLoading || allDiaryQuery.isLoading || allPainQuery.isLoading,
     hasEntriesInRange,
     hasEntriesOverall,
     handleDateChange,


### PR DESCRIPTION
## Summary

- **`pain.ts`**: Add `?from=&to=` date filtering to `GET /pain` (same pattern as diary; enables server-side range filtering)
- **`schemas.ts`**: Add `.max(50)` to `chatRange` and `lastRange` to reject oversized values at the boundary
- **`env.ts`**: Throw at startup if `COOKIE_SECURE` is falsy in production
- **`use-dashboard.ts`**: Pass `from`/`to` params to diary/pain queries (extended range covering prev+current period); add separate unfiltered queries for global all-time best streak, unaffected by the active date filter
- **`memorable-days.tsx` → `memorable-day-modal.tsx`**: Extract the draft modal + emoji picker into its own component; move shared CSS constants to `memorable-days-constants.ts`; reduces `memorable-days.tsx` from 706 to ~243 lines and eliminates emoji-picker state drilling

## Test plan

- [ ] `bun test` in backend — 230 pass
- [ ] `vitest run` in frontend — 71 pass
- [ ] `tsc -b && vite build` frontend — no errors
- [ ] `tsc --noEmit` backend — no errors

Closes #175

Co-Authored-By: claude-sonnet-4-6
75% AI / 25% Human
claude-sonnet-4-6: implemented all 5 fixes
Human: reviewed and approved decisions